### PR TITLE
Disables veteran only

### DIFF
--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -39,7 +39,7 @@
 		/obj/item/clothing/head/collectable/captain = 4,
 	)
 
-	veteran_only = TRUE
+	veteran_only = FALSE
 	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
 
 /datum/outfit/job/blueshield

--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_species.dm
@@ -26,7 +26,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_HUMAN
 	skinned_type = /obj/item/stack/sheet/animalhide/human
-	veteran_only = TRUE
+	veteran_only = FALSE
 
 /datum/species/hemophage/allows_food_preferences()
 	return FALSE

--- a/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -37,7 +37,7 @@
 		/obj/item/reagent_containers/cup/glass/bottle/champagne = 10
 	)
 
-	veteran_only = TRUE
+	veteran_only = FALSE
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
 
 /datum/outfit/job/nanotrasen_consultant

--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -12,7 +12,7 @@
 	value = 0
 	mob_trait = TRAIT_OVERSIZED
 	icon = FA_ICON_EXPAND_ARROWS_ALT
-	veteran_only = TRUE
+	veteran_only = FALSE
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	/// Saves refs to the original (normal size) organs, which are on ice in nullspace in case this quirk gets removed somehow.
 	var/list/obj/item/organ/old_organs

--- a/modular_nova/modules/pet_owner/pet_owner.dm
+++ b/modular_nova/modules/pet_owner/pet_owner.dm
@@ -4,7 +4,7 @@
 	icon = FA_ICON_HORSE
 	value = 4
 	mob_trait = TRAIT_PET_OWNER
-	veteran_only = TRUE
+	veteran_only = FALSE
 	gain_text = span_notice("You brought your pet with you to work.")
 	lose_text = span_danger("You feel lonely, as if leaving somebody behind...")
 	medical_record_text = "Patient mentions their fondness for their pet."

--- a/modular_nova/modules/shapeshifter_quirk/code/shapeshifter_quirk.dm
+++ b/modular_nova/modules/shapeshifter_quirk/code/shapeshifter_quirk.dm
@@ -6,7 +6,7 @@
 	lose_text = span_notice("Your body loses its alterable feeling.")
 	medical_record_text = "Patient has an unusual physiology that allows them to physically transform their body."
 	value = 8
-	veteran_only = TRUE
+	veteran_only = FALSE
 	quirk_flags = QUIRK_HUMAN_ONLY
 
 /datum/quirk/shapeshifter/add(client/client_source)

--- a/modular_nova/modules/veteran_only/code/job_types.dm
+++ b/modular_nova/modules/veteran_only/code/job_types.dm
@@ -1,5 +1,5 @@
 /datum/job/clown
-	veteran_only = TRUE
+	veteran_only = FALSE
 
 /datum/job/mime
-	veteran_only = TRUE
+	veteran_only = FALSE

--- a/modular_nova/modules/veteran_only/code/species_types.dm
+++ b/modular_nova/modules/veteran_only/code/species_types.dm
@@ -1,2 +1,2 @@
 /datum/species/snail
-	veteran_only = TRUE
+	veteran_only = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Disables veteran only quirks and jobs.

## Why it's Good for the Game

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
We don't do the veteran system here.
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
It's word changes, trust me.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Disables veteran only
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
