### PR TITLE
Railing layer change

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -8,7 +8,7 @@
 	density = TRUE
 	anchored = TRUE
 	pass_flags_self = LETPASSTHROW|PASSSTRUCTURE
-	layer = ABOVE_TREE_LAYER
+	layer = ABOVE_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
 	/// armor is a little bit less than a grille. max_integrity about half that of a grille.
 	armor_type = /datum/armor/structure_railing


### PR DESCRIPTION
## About The Pull Request

Changes the layer of the railings so they don't overlay on top of things they shouldn't like machinery while still overlaying things they should like people. This does make them not overlay over trees but in my testing I noticed trees overlay over literally everything no matter where it is so that seems like a tree issue and not an issue with the railings

## Why it's Good for the Game

Fixes visual shit

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
Before:

![image](https://github.com/user-attachments/assets/ac86777f-24d2-4ef9-a156-f095c3938701)

After:

![image](https://github.com/user-attachments/assets/46d8cac8-c593-4eca-8a4c-2048f2028fb7)
![image](https://github.com/user-attachments/assets/1eff69b8-6059-4c45-9402-4d32edaf7b0b)
</details>

## Changelog
:cl:
image: Large machinery such as gravity generators or cryo tubes will overlay on top of railings
code: Code change to layering of railings
/:cl:
