### PR TITLE
Adds an autodrobe to kilo dorms

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -62656,7 +62656,7 @@
 "tGn" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "tGx" = (


### PR DESCRIPTION
## About The Pull Request
It somehow got replaced with soda dispenser during porting.

## Why it's Good for the Game
Only other one that exists is in the theatre which is bad.

## Proof of Testing

![vndor](https://github.com/user-attachments/assets/dcb6a205-192a-4a5a-8739-492cc6ac02d7)

## Changelog

:cl:
map: Added an autodrobe to kilo dorms
/:cl:
