### PR TITLE
Kilostation update

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7871,6 +7871,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/mob/living/basic/pet/cat/runtime,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)
 "ctf" = (


### PR DESCRIPTION
## About The Pull Request

Actually this turned into a general update.
Updates decals, mainly just fixing some stray ones and changing rusted walls to normal ones if they aren't in maintenance area.

## Why it's Good for the Game

Makes maintenance areas make more sense and adds a kitchen in there because its cool.
Decals in random places are bad and I want to make kilo look nice in non-maintenance areas.

## Proof of Testing

![maintkitchen](https://github.com/user-attachments/assets/c3034b72-c815-4a6f-b179-8554bba5257d)

## Changelog

:cl:
map: Gave Kilostation another update
/:cl: