### PR TITLE
Mapfixing

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_lodge.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_lodge.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "aw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -36,7 +36,7 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "aU" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -48,7 +48,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "bs" = (
 /obj/machinery/door/airlock/wood{
@@ -84,7 +84,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "bX" = (
 /obj/structure/table,
@@ -134,7 +134,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "cQ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -189,7 +189,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "dC" = (
 /obj/machinery/door/airlock/wood{
@@ -213,7 +213,7 @@
 /obj/structure/railing/corner{
 	color = "#beada5"
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/huntinglodge)
 "dQ" = (
 /obj/effect/decal/cleanable/wrapping,
@@ -305,13 +305,13 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fi" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "fB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -337,7 +337,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gu" = (
 /obj/structure/table/wood,
@@ -401,7 +401,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gY" = (
 /turf/open/floor/light/colour_cycle/dancefloor_b,
@@ -410,7 +410,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "hb" = (
 /obj/structure/railing{
@@ -541,7 +541,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "jp" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -868,7 +868,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "oY" = (
 /obj/structure/railing{
@@ -881,7 +881,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "pl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -983,7 +983,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "qL" = (
 /obj/structure/table/wood/fancy/orange,
@@ -1038,7 +1038,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "rI" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -1048,7 +1048,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "rS" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1061,7 +1061,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "sX" = (
 /obj/structure/table/wood/fancy/royalblack,
@@ -1217,7 +1217,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "vO" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1304,7 +1304,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "wP" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -1481,7 +1481,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "yO" = (
 /obj/effect/decal/cleanable/garbage,
@@ -1595,7 +1595,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "AF" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -1789,7 +1789,7 @@
 /obj/effect/decal/cleanable/blood/trails{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Ds" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1962,7 +1962,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Fw" = (
 /obj/structure/railing{
@@ -2037,7 +2037,7 @@
 	dir = 4;
 	color = "#beada5"
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Gn" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2112,7 +2112,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Hi" = (
 /obj/structure/table/wood/fancy,
@@ -2177,7 +2177,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Hw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2208,7 +2208,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "HL" = (
 /obj/structure/table/wood,
@@ -2375,7 +2375,7 @@
 	dir = 8;
 	color = "#beada5"
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "KB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -2536,14 +2536,14 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "NW" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Oa" = (
 /obj/effect/turf_decal/siding/wood,
@@ -2646,7 +2646,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Pa" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
@@ -2685,7 +2685,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "PS" = (
 /obj/effect/spawner/structure/window/reinforced{
@@ -2837,7 +2837,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Sp" = (
 /obj/effect/decal/cleanable/blood/trails{
@@ -2911,7 +2911,7 @@
 /obj/effect/decal/cleanable/blood/trails{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "TC" = (
 /obj/effect/decal/cleanable/blood,
@@ -3043,7 +3043,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/dim/directional/west,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/huntinglodge)
 "VW" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -3053,7 +3053,7 @@
 	pixel_x = -4;
 	pixel_y = -15
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Wn" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -3109,7 +3109,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "Xk" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3150,7 +3150,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "XF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3207,7 +3207,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "YD" = (
 /obj/effect/spawner/structure/window/reinforced{
@@ -3266,14 +3266,14 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "ZA" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
 /obj/machinery/light/small/dim/directional/east,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/huntinglodge)
 "ZB" = (
 /obj/structure/table/wood/fancy,

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
@@ -177,7 +177,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "cb" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -366,7 +366,7 @@
 /obj/structure/railing{
 	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "eO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1500,7 +1500,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "ue" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -1524,7 +1524,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "uq" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -1589,7 +1589,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "uH" = (
 /obj/effect/decal/cleanable/blood/footprints,
@@ -1749,7 +1749,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "wd" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -1927,7 +1927,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 5
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "xz" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -2154,7 +2154,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "zF" = (
 /obj/effect/turf_decal/trimline/green/corner,
@@ -2217,7 +2217,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Ax" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -2298,7 +2298,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Br" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
@@ -2419,13 +2419,13 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Dl" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Do" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -2825,7 +2825,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "IR" = (
 /obj/effect/turf_decal/trimline/purple/line{
@@ -2848,7 +2848,7 @@
 	dir = 1
 	},
 /obj/structure/railing/corner,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Jk" = (
 /obj/machinery/door/firedoor,
@@ -2922,7 +2922,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 10
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "JZ" = (
 /obj/effect/decal/cleanable/blood/trails{
@@ -2971,7 +2971,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "KE" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -3076,7 +3076,7 @@
 	},
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/machinery/light/warm/dim/directional/north,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/syndibiodome)
 "Ly" = (
 /obj/structure/aquarium/prefilled,
@@ -3315,7 +3315,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Nt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3922,7 +3922,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "Uc" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4015,7 +4015,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "UI" = (
 /obj/item/flashlight/lantern/on,
@@ -4416,7 +4416,7 @@
 /obj/structure/railing{
 	dir = 6
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/icemoon/surface/outdoors/noteleport)
 "ZT" = (
 /obj/machinery/light/warm/directional/south,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2092,8 +2092,8 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Connector"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
 "aGC" = (
@@ -10931,13 +10931,13 @@
 /area/station/command/bridge)
 "dsm" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "dsw" = (
@@ -25607,13 +25607,13 @@
 /area/station/cargo/storage)
 "hOJ" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "hOK" = (
@@ -36998,12 +36998,12 @@
 /area/station/cargo/sorting)
 "lpp" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/vomit/old,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
 "lpt" = (
@@ -40603,8 +40603,6 @@
 /obj/machinery/door/airlock/asylum{
 	name = "Crack Den"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/fore)
 "mtV" = (
@@ -41125,7 +41123,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "mCk" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -41135,6 +41132,7 @@
 /obj/machinery/door/airlock/service{
 	name = "Abandoned Gambling Den"
 	},
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_wrestle)
 "mCE" = (
@@ -41247,7 +41245,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/chapel/monastery)
 "mEj" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -41258,6 +41255,7 @@
 /obj/machinery/door/airlock/service{
 	name = "Abandoned Theater"
 	},
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/service/theater/abandoned)
 "mEG" = (
@@ -43389,11 +43387,11 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Connector"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
 "npi" = (
@@ -45218,7 +45216,7 @@
 	name = "Crack Den"
 	},
 /obj/structure/barricade/wooden/crude,
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/fore)
 "nSq" = (
@@ -46196,10 +46194,11 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Filter Chamber"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/welded,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/aft)
 "omw" = (
@@ -53708,7 +53707,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/research)
 "qEs" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53720,6 +53718,7 @@
 /obj/machinery/door/airlock/service{
 	name = "Abandoned Gambling Den"
 	},
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_wrestle)
 "qEu" = (
@@ -58886,7 +58885,6 @@
 /area/station/engineering/storage/tech)
 "sft" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -59121,7 +59119,6 @@
 "sjV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -59966,8 +59963,8 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Filter Chamber"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/aft)
 "sxn" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22767,9 +22767,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"hbE" = (
-/turf/closed/wall/r_wall/rust,
-/area/station/command/bridge)
 "hbS" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -27973,9 +27970,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"ivG" = (
-/turf/closed/wall/rust,
-/area/station/command/bridge)
 "ivP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -61982,9 +61976,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"tdk" = (
-/turf/closed/wall/rust,
-/area/station/commons/storage/art)
 "tdt" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -101350,7 +101341,7 @@ aeu
 agt
 efG
 mZR
-qlC
+efG
 vsX
 iWG
 gwu
@@ -102920,7 +102911,7 @@ lbO
 lbO
 lbO
 lbO
-tdk
+plX
 plX
 xZi
 rqq
@@ -103667,8 +103658,8 @@ efG
 efG
 qVk
 efG
-qlC
-qlC
+efG
+efG
 efG
 ize
 lqy
@@ -104181,7 +104172,7 @@ pGS
 sTO
 efG
 gUZ
-qlC
+efG
 nvm
 ags
 dXI
@@ -104695,7 +104686,7 @@ fuX
 vlv
 qlC
 sEK
-qlC
+efG
 efG
 efG
 vrd
@@ -108334,9 +108325,9 @@ eyU
 cEr
 cEr
 qxA
-ivG
 cEr
-hbE
+cEr
+fYh
 fYh
 fYh
 utH
@@ -109363,7 +109354,7 @@ cEr
 cEr
 hNR
 cEr
-ivG
+cEr
 cEr
 fYh
 fYh

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1860,6 +1860,7 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/box/red,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/engineering/supermatter/room)
 "aCE" = (
@@ -3434,7 +3435,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bed" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/biohazard/directional/east,
@@ -7674,6 +7674,7 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/box/red,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/engineering/supermatter/room)
 "cqi" = (
@@ -21776,6 +21777,7 @@
 /obj/structure/sign/poster/random/directional/south,
 /obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/box/red,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/medical/treatment_center)
 "gJc" = (
@@ -34955,7 +34957,6 @@
 /area/station/maintenance/port/greater)
 "kFG" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -39334,6 +39335,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/security/corrections_officer)
+"mar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/restrooms)
 "mav" = (
 /obj/structure/sign/departments/security/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -45358,6 +45364,7 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/box/red,
 /obj/machinery/shower/directional/north,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/engineering/storage_shared)
 "nVc" = (
@@ -55612,6 +55619,7 @@
 "rhl" = (
 /obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/box/red,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/medical/treatment_center)
 "rhv" = (
@@ -56465,7 +56473,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "rsZ" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66290,6 +66297,7 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 5
 	},
+/obj/structure/drain,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "uyd" = (
@@ -71801,6 +71809,7 @@
 "wbD" = (
 /obj/machinery/shower/directional/north,
 /obj/effect/turf_decal/box/red,
+/obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/security/medical)
 "wbG" = (
@@ -103644,7 +103653,7 @@ aUz
 aeu
 uNO
 kfH
-mIh
+mar
 tQs
 nEE
 quK

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -5716,6 +5716,18 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
+/obj/item/hfr_box/corner{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = 8;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "byQ" = (
@@ -12630,6 +12642,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
 	dir = 10
 	},
+/obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "dul" = (
@@ -13241,6 +13254,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -20965,6 +20981,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/forestarboardhall)
+"fHI" = (
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 8
+	},
+/obj/machinery/bluespace_vendor/directional/west,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/hallway/primary/starboard)
 "fHQ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -29566,12 +29591,11 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/door/firedoor,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -30953,6 +30977,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -31374,6 +31399,18 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/common/night_club)
+"iuX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/primary/fore)
 "iuZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
@@ -38408,7 +38445,6 @@
 /area/station/security/checkpoint/medical)
 "knr" = (
 /obj/structure/cable,
-/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -41580,6 +41616,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
+"lfh" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/hallway/primary/fore)
 "lfi" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/stairs{
@@ -41813,8 +41859,8 @@
 /area/station/engineering/supermatter/room)
 "lhW" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "lhZ" = (
@@ -43677,6 +43723,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningfoyer)
+"lJd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/primary/fore)
 "lJe" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46990,6 +47049,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 9
 	},
+/obj/machinery/bluespace_vendor/directional/west,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/port)
 "mFh" = (
@@ -48231,6 +48291,17 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"mYe" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/obj/machinery/bluespace_vendor/directional/north,
+/turf/open/floor/iron/edge,
+/area/station/hallway/primary)
 "mYl" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard{
@@ -48997,6 +49068,7 @@
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -56579,11 +56651,11 @@
 "phD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -58754,6 +58826,18 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/security/medical)
+"pPS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/hallway/primary/fore)
 "pPV" = (
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/engine/xenobio,
@@ -62330,9 +62414,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/random/directional/east,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -67838,6 +67919,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 9
 	},
+/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "srr" = (
@@ -78579,7 +78661,6 @@
 "vkF" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/herringbone,
 /area/station/hallway/primary/fore)
 "vkM" = (
@@ -86387,6 +86468,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/xenobiology)
+"xlN" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/herringbone,
+/area/station/hallway/primary/fore)
 "xmb" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -248983,7 +249069,7 @@ osG
 awE
 awE
 osG
-nHL
+mYe
 eKs
 kbr
 jiA
@@ -259229,7 +259315,7 @@ yeR
 tPl
 sNr
 hTv
-tMc
+lJd
 wwa
 jhV
 fDx
@@ -259484,7 +259570,7 @@ yeR
 fLD
 yeR
 lFa
-cHZ
+lfh
 vkF
 hXw
 wwa
@@ -259509,7 +259595,7 @@ cJl
 hQV
 jvD
 xqR
-jvD
+fHI
 oeT
 cMn
 cMn
@@ -259741,8 +259827,8 @@ vUw
 uPr
 yeR
 bNP
-dwL
-cRw
+sNr
+hTv
 phD
 lhW
 kwK
@@ -259999,8 +260085,8 @@ kAc
 yeR
 trS
 sNr
-hTv
-tMc
+xlN
+iuX
 lQg
 lkk
 xcs
@@ -260255,9 +260341,9 @@ lOX
 tjX
 yeR
 bDD
-sNr
-hTv
-tMc
+dwL
+cRw
+pPS
 lQg
 lQg
 lQg

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -12542,7 +12542,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "enq" = (
 /obj/machinery/duct,
@@ -25654,6 +25654,7 @@
 "iLw" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/qm)
 "iLx" = (


### PR DESCRIPTION
## About The Pull Request
Updates biodome and kilo, first one got an air alarm in quartermasters office, while other got more non-abandoned maintenance doors. I updated snowglobe because I'm tired of seeing it miss stuff for like 2 months lol. Also fixes roundstart active turfs on it.
## Why it's Good for the Game
Rounstart active turfs bad, floating lights bad, uh...disposals and vents in firelocks are also bad. Should stop permanent fire alarms on biodome. Expands kilo maintenance a little since it won't be so locked up with abandoned doors.
## Proof of Testing

![mithingy](https://github.com/user-attachments/assets/429799f3-980e-4528-974f-5fdeff0f8326)

Checked for active turfs by restarting the game 3 times
## Changelog

:cl:
map: Updated Kilostation, Biodome and Snowglobe
/:cl:
