### PR TITLE
Map Updates

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -219,6 +219,15 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"abN" = (
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "abX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -3569,7 +3578,6 @@
 "bhB" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/airalarm/directional/north,
@@ -4463,6 +4471,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "bvA" = (
@@ -5755,6 +5764,12 @@
 /obj/structure/sign/poster/official/love_ian/directional/north,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"bQJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "bQN" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -6572,12 +6587,11 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ccu" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "ccH" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/watertank,
@@ -9357,6 +9371,7 @@
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/interrogation)
 "cUy" = (
@@ -9506,6 +9521,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/science{
 	name = "Xenobiology Lab"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -9663,8 +9681,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/tile/dark_purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/hot_pink/opposingcorners{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "cXX" = (
 /obj/machinery/light/directional/west,
@@ -9985,6 +10010,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 12
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -10571,6 +10599,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"dnQ" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "dod" = (
 /obj/effect/landmark/start/head_of_personnel,
 /obj/structure/chair/office{
@@ -10807,6 +10840,10 @@
 /obj/machinery/door/window/right/directional/west{
 	req_access = list("medical");
 	name = "Medbay Storage"
+	},
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
@@ -11723,6 +11760,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"dHz" = (
+/obj/effect/spawner/random/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "dHC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12147,7 +12189,6 @@
 /obj/structure/water_source/puddle,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light_switch/directional/south,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
@@ -15098,6 +15139,7 @@
 	network = list("aiupload")
 	},
 /obj/machinery/computer/security/telescreen/aiupload/directional/west,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -15932,6 +15974,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "eWH" = (
@@ -16122,12 +16165,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/steam_vent,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "eZm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17400,9 +17444,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
-"frO" = (
-/turf/closed/wall/r_wall,
-/area/station/science/genetics)
 "fse" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -17792,6 +17833,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "fxB" = (
@@ -18811,6 +18853,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "fLD" = (
@@ -21208,16 +21251,21 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Xenobiology Maintenance"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "gzq" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard)
 "gzv" = (
@@ -21722,6 +21770,7 @@
 "gIw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "gIz" = (
@@ -22857,6 +22906,7 @@
 /area/station/science/lab)
 "hcM" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/interrogation)
 "hcP" = (
@@ -23737,12 +23787,11 @@
 /area/station/engineering/lobby)
 "hnF" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
-/obj/machinery/door/airlock/science{
-	name = "Xenobiology Lab"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "hnL" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -23951,18 +24000,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
-"hqN" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Containment Pen 4";
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("xenobiology");
-	name = "Containment Pen 4"
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "hqS" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -23981,6 +24018,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"hrm" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "hrM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24494,15 +24535,6 @@
 "hAP" = (
 /turf/closed/wall/r_wall,
 /area/station/security/evidence)
-"hAS" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology Cell 2";
-	name = "xenobiology camera";
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "hBa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -24786,6 +24818,10 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/item/toy/plush/slimeplushie{
+	pixel_y = -4;
+	pixel_x = 7
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
@@ -26300,6 +26336,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "hYm" = (
@@ -26665,6 +26702,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "icx" = (
@@ -26935,6 +26973,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"ihp" = (
+/obj/machinery/netpod,
+/obj/machinery/camera/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/bitrunning/den)
 "ihu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28655,7 +28698,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/obj/machinery/door/airlock/science{
+	name = "Xenobiology Lab"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "iFm" = (
 /obj/structure/cable,
@@ -29438,6 +29486,18 @@
 /obj/item/clothing/mask/gas/atmos/frontier_colonist,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/port/fore)
+"iRh" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/west{
+	req_access = list("xenobiology");
+	name = "Containment Pen 6"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 6";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "iRl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -29609,9 +29669,6 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Xenobiology Cell 2";
 	name = "xenobiology camera";
@@ -29623,6 +29680,21 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
@@ -29795,6 +29867,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/bar)
+"iUO" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "iUV" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen/empty,
@@ -29844,6 +29922,7 @@
 /obj/effect/turf_decal/trimline/dark/filled/line{
 	dir = 5
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/abandoned_gambling_den)
 "iVF" = (
@@ -30768,6 +30847,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/station/service/chapel/monastery)
 "jjP" = (
@@ -31057,6 +31137,7 @@
 /obj/item/crowbar,
 /obj/item/analyzer,
 /obj/machinery/digital_clock/directional/west,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "jpF" = (
@@ -32404,6 +32485,7 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "jLu" = (
@@ -32505,20 +32587,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "jMG" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/apc/cell_10k,
-/obj/effect/mapping_helpers/apc/full_charge,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "jMU" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -33014,7 +33091,10 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/obj/effect/turf_decal/tile/dark_purple/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "jXb" = (
 /obj/effect/turf_decal/trimline/hot_pink/filled/corner{
@@ -33287,6 +33367,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
+"kam" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "kan" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -33765,18 +33849,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
-"kjO" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Containment Pen 3";
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("xenobiology");
-	name = "Containment Pen 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "kkb" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/photocopier,
@@ -33840,6 +33912,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"klF" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 3";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/window/left/directional/west{
+	req_access = list("xenobiology");
+	name = "Containment Pen 3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "kml" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
@@ -34413,7 +34497,13 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/stone,
+/obj/effect/turf_decal/tile/dark_purple/anticorner/contrasted,
+/obj/effect/turf_decal/tile/hot_pink/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "kwM" = (
 /obj/effect/turf_decal/tile/brown,
@@ -35231,6 +35321,7 @@
 	},
 /obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/chapel/office)
 "kKm" = (
@@ -36091,6 +36182,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"kYj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "kYp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36100,6 +36196,7 @@
 	dir = 5
 	},
 /mob/living/basic/bot/medbot/autopatrol,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/lobby)
 "kYr" = (
@@ -36243,6 +36340,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/engine/telecomms,
 /area/station/tcommsat/server)
 "laf" = (
@@ -36643,6 +36741,7 @@
 /obj/machinery/shower/directional/east,
 /obj/item/soap/nanotrasen,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/plastic,
 /area/station/security/prison/shower)
 "lhx" = (
@@ -39272,6 +39371,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"lYK" = (
+/obj/effect/turf_decal/tile/dark_purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/hot_pink/opposingcorners,
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/xenobiology)
 "lYX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/tile/neutral,
@@ -40480,14 +40587,11 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/extinguisher{
-	pixel_y = 4
-	},
-/obj/item/extinguisher{
-	pixel_x = -4
-	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/apc/full_charge,
+/obj/effect/mapping_helpers/apc/cell_10k,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "mrQ" = (
@@ -41701,16 +41805,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "mLZ" = (
-/obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Xenobiology Maintenance"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "mMb" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
@@ -41795,6 +41898,7 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/trimline/hot_pink/filled/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "mNv" = (
@@ -42112,18 +42216,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mRW" = (
-/obj/machinery/light_switch/directional/south,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "mSl" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
@@ -44717,6 +44817,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
+"nJY" = (
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "nKj" = (
 /obj/effect/turf_decal/siding/thinplating/dark/end{
 	dir = 4
@@ -46182,7 +46290,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/central)
 "olL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46289,6 +46397,7 @@
 /area/station/engineering/storage/tcomms)
 "onr" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/funeral)
 "onU" = (
@@ -47889,13 +47998,12 @@
 /area/station/maintenance/starboard)
 "oPU" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "oPX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer2{
 	dir = 8
@@ -48244,12 +48352,10 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "oVc" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/extinguisher{
-	pixel_x = -4
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "oVh" = (
 /obj/item/chair/stool{
 	dir = 8;
@@ -48618,9 +48724,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
 "paV" = (
-/obj/structure/table/reinforced/plasmarglass,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "pbs" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/rust,
@@ -48645,6 +48752,8 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
+/obj/machinery/camera/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/service/chapel/dock)
 "pcj" = (
@@ -49268,6 +49377,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/chapel/monastery)
 "pkr" = (
@@ -49651,18 +49761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
-"poH" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Containment Pen 6";
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("xenobiology");
-	name = "Containment Pen 6"
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "poK" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/delivery,
@@ -51314,8 +51412,10 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/stone,
+/obj/effect/turf_decal/tile/dark_purple/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "pQh" = (
 /obj/item/cigbutt/cigarbutt{
@@ -51653,6 +51753,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "pVL" = (
@@ -52298,6 +52400,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qfu" = (
@@ -53258,6 +53361,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/service/lawoffice)
+"qwk" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "qwx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -53825,12 +53932,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"qFT" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/west{
+	req_access = list("xenobiology");
+	name = "Containment Pen 5"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 6";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qGi" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/paper/guides/jobs/engi/gravity_gen,
 /obj/item/pen/blue,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "qGn" = (
@@ -53952,9 +54072,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/evidence)
 "qIE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "qIS" = (
 /obj/structure/railing{
 	dir = 4
@@ -54686,6 +54806,7 @@
 	pixel_y = 5;
 	pixel_x = -5
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -54729,8 +54850,8 @@
 	pixel_y = 4
 	},
 /obj/item/crowbar,
-/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "qUj" = (
@@ -54743,6 +54864,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "qUO" = (
@@ -55053,6 +55175,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "qYO" = (
@@ -55686,6 +55809,7 @@
 	pixel_y = -4;
 	pixel_x = -6
 	},
+/obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/iron/checker,
 /area/station/service/barber)
 "rhE" = (
@@ -57540,6 +57664,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/machinery/light/red/dim/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/interrogation)
 "rKY" = (
@@ -59287,6 +59412,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "smd" = (
@@ -59475,7 +59601,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/central)
 "spm" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
@@ -62008,6 +62134,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "tdW" = (
@@ -62942,6 +63069,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
 "ttB" = (
@@ -63213,6 +63341,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
+"txU" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "tya" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood/old,
@@ -65352,6 +65486,18 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"uhW" = (
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/west{
+	req_access = list("xenobiology");
+	name = "Containment Pen 4"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 4";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uib" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -65994,7 +66140,13 @@
 /obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/obj/effect/turf_decal/tile/dark_purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/hot_pink/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "usV" = (
 /obj/structure/table/wood,
@@ -66141,18 +66293,16 @@
 /turf/open/space/basic,
 /area/station/solars/starboard/aft)
 "uvw" = (
-/obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "uvA" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
@@ -66838,10 +66988,6 @@
 /obj/effect/landmark/navigate_destination/hydro,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"uGJ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "uGR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -67019,16 +67165,9 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "uIz" = (
-/obj/machinery/door/window/left/directional/east{
-	name = "Containment Pen 6";
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/window/left/directional/west{
-	req_access = list("xenobiology");
-	name = "Containment Pen 5"
-	},
 /obj/structure/cable,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "uIP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -67378,10 +67517,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
-"uPM" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "uPX" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -67405,6 +67540,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/warehouse)
 "uQF" = (
@@ -67553,6 +67689,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "uSH" = (
@@ -67735,7 +67872,6 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/obj/item/toy/plush/slimeplushie,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "uWQ" = (
@@ -68269,6 +68405,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -69547,6 +69684,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vww" = (
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "vwx" = (
@@ -69789,6 +69927,13 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/light/small/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/extinguisher{
+	pixel_y = 4
+	},
+/obj/item/extinguisher{
+	pixel_x = -4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "vzZ" = (
@@ -70662,21 +70807,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vKU" = (
-/obj/structure/table/reinforced/plasmarglass,
-/obj/item/experi_scanner{
-	pixel_x = 4
-	},
-/obj/item/experi_scanner{
-	pixel_x = 4
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "vLg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -70859,7 +70994,6 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "vOn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -70977,9 +71111,6 @@
 	c_tag = "Engineering Foyer";
 	name = "engineering camera";
 	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -71340,41 +71471,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
-"vVE" = (
-/obj/machinery/newscaster/directional/east,
-/obj/structure/table/reinforced/plasmarglass,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "vVM" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -72227,13 +72323,16 @@
 	},
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Xenobiology Maintenance"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "whj" = (
 /obj/structure/girder,
@@ -73602,6 +73701,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/nuke_storage)
+"wFQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/security/prison/safe)
 "wFS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74752,6 +74856,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/turf_decal/stripes/red/corner,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/execution/transfer)
 "wWm" = (
@@ -75114,6 +75219,7 @@
 	id = "ntrep_shutters";
 	req_access = list("command")
 	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/nt_rep)
 "xbZ" = (
@@ -75723,6 +75829,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xlF" = (
@@ -76871,6 +76978,7 @@
 /obj/effect/turf_decal/tile/dark_purple{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
 "xFE" = (
@@ -77226,6 +77334,8 @@
 	dir = 1;
 	name = "Distro to Waste"
 	},
+/obj/machinery/camera/directional/east,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "xMx" = (
@@ -77401,6 +77511,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "xQj" = (
@@ -78146,7 +78257,6 @@
 "yaK" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -85456,7 +85566,7 @@ dWG
 oYA
 dap
 gpc
-dap
+wFQ
 dWG
 dWG
 uTW
@@ -106540,7 +106650,7 @@ ulS
 mbp
 fNe
 bVR
-uPM
+bVR
 suo
 nVK
 vWH
@@ -107824,7 +107934,7 @@ boq
 xwE
 xGw
 aQs
-rsw
+txU
 hAJ
 kIf
 rIk
@@ -114714,7 +114824,7 @@ vJc
 vJc
 qIE
 mLZ
-vJc
+lZi
 mrA
 fJq
 vnH
@@ -114963,15 +115073,15 @@ oEN
 uRW
 qmW
 eWT
-qmW
 oEN
 uRW
 qmW
-hAS
-qmW
-oEN
-uvw
+vnd
+iDK
 vJc
+lRk
+uvw
+lZi
 uDT
 kLm
 hpC
@@ -115220,15 +115330,15 @@ oEN
 uRW
 qmW
 vAL
-qmW
 oEN
 uRW
 qmW
 vAL
 qmW
-oEN
-jMG
 vJc
+abN
+jMG
+lZi
 lhJ
 mQu
 ggZ
@@ -115477,15 +115587,15 @@ oEN
 uRW
 qmW
 qmW
-qmW
 oEN
 uRW
 qmW
 qmW
 qmW
-oEN
-mRW
 vJc
+dHz
+mRW
+lZi
 sgW
 uJP
 dMW
@@ -115732,17 +115842,17 @@ rjA
 lev
 lev
 lev
-lev
-kjO
-lev
-lev
-lev
-lev
+klF
 uIz
 lev
 lev
-eZi
+qFT
+lev
+uIz
 vJc
+nJY
+eZi
+lZi
 iKo
 oHP
 xjT
@@ -115996,8 +116106,8 @@ hrM
 hrM
 hrM
 hrM
-hrM
-hrM
+vJc
+vJc
 gzm
 vJc
 tFq
@@ -116239,7 +116349,7 @@ pit
 uyR
 jYD
 eRh
-efq
+kYj
 efq
 efq
 efq
@@ -116253,10 +116363,10 @@ fwr
 bMc
 lwe
 lwe
-uGJ
+vJc
 cXW
 usG
-frO
+vJc
 oMA
 spG
 hIq
@@ -116500,7 +116610,7 @@ wPC
 nxI
 cSN
 qzI
-nxI
+dnQ
 nxI
 nxI
 cSN
@@ -116767,10 +116877,10 @@ oqo
 oqo
 oqo
 lwe
-lwe
-lwe
+vJc
+lYK
 kwu
-frO
+vJc
 yaK
 pSe
 iBh
@@ -117024,11 +117134,11 @@ hrM
 hrM
 hrM
 hrM
-hrM
-hrM
+vJc
+vJc
 whd
-vJc
-vJc
+lDu
+lDu
 nfX
 vIR
 nfX
@@ -117274,18 +117384,18 @@ cID
 lev
 lev
 lev
-lev
-hqN
-lev
-lev
+uhW
+uIz
 lev
 lev
-poH
+iRh
 lev
-lev
+uIz
+qwk
+iUO
 ccu
 oVc
-vJc
+lDu
 bhB
 xvr
 kkT
@@ -117533,16 +117643,16 @@ oEN
 uRW
 qmW
 qmW
-qmW
 oEN
 uRW
 qmW
 qmW
 qmW
-oEN
+vJc
+paV
 oPU
 paV
-vJc
+lDu
 jOZ
 qhx
 lVL
@@ -117790,16 +117900,16 @@ oEN
 uRW
 qmW
 vAL
-qmW
 oEN
 uRW
 qmW
 vAL
 qmW
-oEN
-oPU
-vKU
 vJc
+fIl
+bQJ
+vKU
+lDu
 rwu
 roF
 pMT
@@ -118047,16 +118157,16 @@ oEN
 uRW
 qmW
 yhM
-qmW
 oEN
 uRW
 qmW
-yhM
-qmW
-oEN
-oPU
-vVE
+lYJ
+nrf
 vJc
+kam
+bQJ
+rZV
+lDu
 bkK
 xLC
 tnR
@@ -118308,12 +118418,12 @@ vJc
 vJc
 vJc
 vJc
-vJc
 uYy
 vJc
+fIl
 hnF
-vJc
-vJc
+hrm
+lDu
 wZZ
 ubU
 wIo
@@ -119110,7 +119220,7 @@ jzG
 tRe
 mVG
 emg
-pGm
+ihp
 tRe
 kDZ
 hhu

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -4313,8 +4313,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/storage/belt/medical,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/defibrillator/loaded,
-/obj/item/defibrillator/loaded,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bwN" = (
@@ -9213,17 +9211,6 @@
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/carpet/neon/simple/blue,
 /area/station/commons/dorms)
-"dfH" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/defibrillator/loaded,
-/turf/open/floor/iron/dark,
-/area/station/medical/storage)
 "dfI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -58851,7 +58838,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/auxbase/directional/east,
+/obj/machinery/computer/security/telescreen/auxbase/directional/west,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "tIJ" = (
@@ -62782,6 +62769,15 @@
 /area/station/biodome/aft)
 "vfF" = (
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/left/directional/north{
+	name = "Secure Medical Storage"
+	},
+/obj/item/defibrillator/loaded,
+/obj/item/defibrillator/loaded,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "vfK" = (
@@ -158190,7 +158186,7 @@ nKV
 jOb
 aEh
 pPs
-dfH
+bwK
 xXK
 jBW
 eFt

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -127,7 +127,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## "HUMAN_WHITELIST": all heads-of-staff jobs will be able to be played by non-humans, unless that job incorporates the "human only" flag (Which can be configured via a variable or the job config txt).
 ## "NON_HUMAN_WHITELIST": non-humans will not be able to play as heads of staff, unless that job incorporates the "allow non-humans" flag (Which can be configured via a variable or the job config txt).
 ## "ENFORCED": non-humans cannot be heads of staff, only humans can. the "allow non-humans" setting will be ignored.
-HUMAN_AUTHORITY HUMAN_WHITELIST
+HUMAN_AUTHORITY DISABLED
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS


### PR DESCRIPTION
## About The Pull Request
Adds lots of missing things to kilo, moves defibs away to a separate place on biodome, disables human authority by default

## Why it's Good for the Game

Expands maintenance on kilo a bit, adds missing things. Makes it easier to revive people in biodome since you don't have to make a chainsaw to break open a locker. Config change only affects debugging stuff locally, does not affect the server. Pretty much changes it back to previous behaviour like before the update.

## Proof of Testing

Works if checks are green, map changes are in mapdiff bot.

## Changelog

:cl:
map: Updated kilostation and biodome
config: Disabled human authority by default
/:cl:
