### PR TITLE
Brings back cursed quirk

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -63374,12 +63374,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
-"txU" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "tya" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood/old,
@@ -107979,7 +107973,7 @@ boq
 xwE
 xGw
 aQs
-txU
+rsw
 hAJ
 kIf
 rIk

--- a/code/datums/quirks/negative_quirks/cursed.dm
+++ b/code/datums/quirks/negative_quirks/cursed.dm
@@ -1,5 +1,3 @@
-/*
-// NOVA EDIT REMOVAL
 /datum/quirk/cursed
 	name = "Cursed"
 	desc = "You are cursed with bad luck. You are much more likely to suffer from accidents and mishaps. When it rains, it pours."
@@ -13,5 +11,3 @@
 
 /datum/quirk/cursed/add(client/client_source)
 	quirk_holder.AddComponent(/datum/component/omen/quirk)
-*/
-// NOVA EDIT REMOVAL END


### PR DESCRIPTION
## About The Pull Request

Also removes one thing I forgot to delete on kilo

## Why it's Good for the Game

That quirk was removed only because skyrat's host didn't like it, this ain't skyrat. It's also one of the more unique quirks in the game.

## Proof of Testing

I joined and was instantly assaulted by broken lights shocking me and airlocks doing a funny, think it works lol

## Changelog

:cl:
add: cursed quirk is back
map: removed a hallway lightswitch on kilo
/:cl:
