### PR TITLE
Fixes burn chambers on kilo and biodome

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7628,15 +7628,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
-"coU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
 "cpb" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -20129,6 +20120,7 @@
 /obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/mob/living/basic/trooper/russian,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "ghp" = (
@@ -24510,6 +24502,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "hzO" = (
@@ -25783,6 +25776,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"hPS" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "hPX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35089,6 +35088,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/pump,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "kFR" = (
@@ -36191,6 +36191,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
+"kXU" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "kXV" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/cable,
@@ -36768,6 +36779,12 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/plastic,
 /area/station/security/prison/shower)
+"lhw" = (
+/obj/machinery/light/small/red/dim/directional/west,
+/obj/effect/decal/cleanable/blood/innards,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "lhx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37048,6 +37065,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/interrogation)
+"lnw" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "lnD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39752,15 +39777,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/greater)
-"mfC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard)
 "mfD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -44407,6 +44423,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "nEr" = (
@@ -46716,6 +46733,12 @@
 "otP" = (
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
+"oue" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/structure/table,
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "ouk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/cable,
@@ -51759,7 +51782,8 @@
 	dir = 1
 	},
 /mob/living/basic/rabbit{
-	name = "Princess"
+	name = "Princess";
+	real_name = "Princess"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -67196,6 +67220,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"uIO" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "uIP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67973,6 +68001,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "uYp" = (
@@ -69009,6 +69038,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"vno" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/station/science/ordnance)
 "vns" = (
 /obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -69044,7 +69077,7 @@
 /area/station/hallway/primary/aft)
 "vnO" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/trooper/russian,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "vnP" = (
@@ -72600,6 +72633,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/fore)
+"wkE" = (
+/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/structure/table,
+/obj/item/paper/crumpled/bloody{
+	default_raw_text = "Behind you";
+	name = "Bloodied Note"
+	},
+/turf/open/floor/fake_iron_sand,
+/area/station/service/abandoned_gambling_den)
 "wkT" = (
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock";
@@ -72770,6 +72812,8 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance/burnchamber)
 "wny" = (
@@ -112278,7 +112322,7 @@ aLh
 cpl
 cpl
 cpl
-aeu
+cpl
 cIV
 cIX
 cIX
@@ -112533,9 +112577,9 @@ lWU
 keg
 adV
 cpl
-aeu
-aeu
-aeu
+kXU
+lhw
+oue
 cIV
 cIX
 cIX
@@ -112790,9 +112834,9 @@ lWU
 keg
 pQh
 cpl
-aeu
-aeu
-aeu
+lnw
+hPS
+wkE
 cIU
 cIX
 cIX
@@ -113047,7 +113091,7 @@ lWU
 keg
 ntf
 cpl
-cpl
+uIO
 cpl
 cpl
 cpl
@@ -118977,7 +119021,7 @@ kEX
 jrI
 hXc
 hFT
-coU
+wCY
 nDp
 vOX
 vnO
@@ -120521,7 +120565,7 @@ syF
 rZV
 eNy
 wCY
-mfC
+xZL
 vOX
 rZV
 lDu
@@ -121046,7 +121090,7 @@ pii
 sbd
 lkB
 lkB
-lkB
+vno
 lkB
 lkB
 lkB
@@ -121303,7 +121347,7 @@ kYr
 eUM
 xVN
 lfz
-lkB
+vno
 lkB
 lkB
 lkB

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1263,13 +1263,13 @@
 	},
 /area/station/security/office)
 "auN" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark_red,
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
 "auO" = (
@@ -3539,7 +3539,7 @@
 /area/station/science/genetics)
 "bip" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "biu" = (
 /obj/machinery/camera/directional/east{
@@ -19412,6 +19412,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/turf_decal/siding/dark_red,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "gzQ" = (
@@ -23327,7 +23328,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "hVQ" = (
 /obj/structure/chair/sofa/bench{
@@ -34588,6 +34589,8 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "lHq" = (
@@ -47506,7 +47509,7 @@
 /obj/machinery/airlock_controller/incinerator_ordmix{
 	pixel_y = -32
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "pZn" = (
 /obj/machinery/vending/sustenance,
@@ -50126,7 +50129,7 @@
 /obj/machinery/airlock_sensor/incinerator_ordmix{
 	pixel_y = -24
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "qRD" = (
 /obj/effect/landmark/event_spawn,
@@ -65167,6 +65170,7 @@
 /obj/item/solar_assembly,
 /obj/item/solar_assembly,
 /obj/item/stack/cable_coil,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "vWr" = (
@@ -70532,7 +70536,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
 /area/station/science/ordnance/burnchamber)
 "xGA" = (
 /turf/open/floor/iron/herringbone,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Also adds a new side room on kilo. Igniters need power to work, which means it needs a functional apc. This adds them on both maps.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
You can do terrorism on kilo and biodome, what's to not like about it.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

![ordi](https://github.com/user-attachments/assets/b86199f4-406f-45c1-b82c-79fa7174ada5)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: made kilo and biodome's burn chambers functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
