### PR TITLE
Makes autopunctuation a preference

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -237,7 +237,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	message_mods[SAY_MOD_VERB] = say_mod(message, message_mods)
 	// NOVA EDIT ADDITION START: autopunctuation
 	//ensure EOL punctuation exists and that word-bounded 'i' are capitalized before we do anything else
-	message = autopunct_bare(message)
+	if(client?.prefs?.read_preference(/datum/preference/toggle/autopunctuation)) //IRIS ADDITION: Can be turned off now
+		message = autopunct_bare(message)
 	// NOVA EDIT ADDITION END
 
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something

--- a/modular_iris/master_files/code/modules/client/preferences/say_prefs.dm
+++ b/modular_iris/master_files/code/modules/client/preferences/say_prefs.dm
@@ -1,0 +1,5 @@
+/datum/preference/toggle/autopunctuation
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "autopunctuation"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6592,6 +6592,7 @@
 #include "modular_iris\maps\biodome\vendcation.dm"
 #include "modular_iris\maps\biodome\weapons.dm"
 #include "modular_iris\master_files\code\modules\client\preferences\footprint_sprite.dm"
+#include "modular_iris\master_files\code\modules\client\preferences\say_prefs.dm"
 #include "modular_iris\master_files\code\modules\mob\living\carbon\human\butts.dm"
 #include "modular_iris\master_files\code\modules\mob\living\carbon\human\human.dm"
 #include "modular_iris\modules\bodyparts\code\_mutant_bodyparts.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/iris/autopunctuation_toggle.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/iris/autopunctuation_toggle.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, FeatureToggle } from '../../base';
+
+export const autopunctuation: FeatureToggle = {
+  name: 'Enable autopunctuation',
+  category: 'CHAT',
+  description: 'Toggle autopunctuation on/off (ex. at the end of messages)',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a preference to autopunctuation, toggled ON by default. Located in game preferences in CHAT section.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
I am personally not a fan of it as it sometimes makes your text weird for example if you want to write out each word as a separate message, leaving it on by default as a toggle because some people like it and toggling it off will be someone's conscious decision.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

![toggle](https://github.com/user-attachments/assets/1c67a565-8a5f-45f4-ae32-c7bbf1558bb1)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a preference toggle for autopunctuation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
