### PR TITLE
Fixes Deltastation Security Maint's wires

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1296,6 +1296,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
 "apC" = (
@@ -17071,7 +17072,6 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "eiU" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -30320,6 +30320,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "hys" = (
@@ -32772,15 +32773,6 @@
 	dir = 4
 	},
 /area/station/security/office)
-"ieh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/department/security)
 "iem" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -41350,8 +41342,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "kjH" = (
 /obj/machinery/nuclearbomb/beer,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security)
 "kjI" = (
@@ -42649,8 +42641,8 @@
 /obj/structure/closet/bombcloset/security,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/cable,
 /obj/machinery/light/small/red/dim/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security)
 "kCV" = (
@@ -50406,7 +50398,6 @@
 	name = "Storage Closet"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -51993,11 +51984,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"mWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security)
 "mWE" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -52725,7 +52711,6 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
@@ -85937,6 +85922,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security)
 "vwe" = (
@@ -148245,7 +148231,7 @@ tsU
 aeY
 hPx
 bJC
-ieh
+eiU
 tuv
 vHY
 tuB
@@ -148759,7 +148745,7 @@ hEF
 dth
 apA
 vwb
-mWB
+vHY
 avF
 vHY
 qJh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deltastation for some reason had weird wiring in Security maints where the wire completely avoided the APC and had this weird wire leading to nowhere so instead the wires only leads through the APC and into the windows

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

the maps have fallen. millions must fix

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing




<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

before change:
![Screenshot 2024-11-30 133714](https://github.com/user-attachments/assets/102f7c00-9141-4c4c-8d7e-27a83a99c389)

after change:
![Screenshot 2024-11-30 133648](https://github.com/user-attachments/assets/fd923c3e-4d9f-4c9f-86fe-048c895de68e)

in-game:
![Screenshot 2024-11-30 140132](https://github.com/user-attachments/assets/a8046515-ec87-4b5c-844c-811249cc9374)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Deltastation security maints are now properly wired
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
