### PR TITLE
Wet, Wild, and Political: Shoredress & Stardress Technology For All!

### DIFF
--- a/modular_nova/modules/akula/code/wetsuit.dm
+++ b/modular_nova/modules/akula/code/wetsuit.dm
@@ -20,8 +20,9 @@
 /datum/component/wetsuit/proc/apply_wetsuit_status_effect(obj/item/source, mob/living/user, slot)
 	if(slot == ITEM_SLOT_HANDS)
 		return FALSE
-	if(!HAS_TRAIT(user, TRAIT_SLICK_SKIN))
-		return FALSE
+//IRIS EDIT: Removes the species-lock that prevents azulean technology from making non-akulans wet
+//	if(!HAS_TRAIT(user, TRAIT_SLICK_SKIN))
+//		return FALSE
 
 	user.apply_status_effect(/datum/status_effect/grouped/wetsuit, REF(source))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the slick skin check on the wetsuit component, allowing Azulean technology from making Non-Akulans wet.

In Plain English: All "Shoredress" items (Akulan Jumpsuits + Hydro-Vaporizer) will now make you (yes, you!) wet when worn.

## Why it's Good for the Game

Players are somewhat limited in their ability to create aquatic characters who are _dependent_ on water, considering wet-stacks fade relatively quickly. Giving them more freedom of expression is a good thing! It was always a little weird that these items discriminated based on species, anyways.

## Proof of Testing

<details>
<summary>Screenshots</summary>
Derrik here was more than willing to take some photos for us. Just look at how he glistens and shines!

![derrik](https://github.com/user-attachments/assets/ff90527f-3e74-4426-a48e-6f2cc4c66fb3)
![derrik 2](https://github.com/user-attachments/assets/4eb45751-de4b-4ab6-8ea0-37ef25753149)



</details>

## Changelog

:cl:
balance: After a great deal of protest amongst the aquatically inclined species of the galaxy, the Azulean Monarchy has finally given in and removed the genetic lock on proprietary Shoredress and Stardress technology. Rejoice, folk of fin and gill, as hydro-vaporizers now provide succor for your parched skin.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
