### PR TITLE
snow-ifies some areas (the snow pr)

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -218,8 +218,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aga" = (
 /obj/structure/table,
@@ -262,11 +261,8 @@
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
 "agA" = (
-/obj/structure/chair/stool/directional/south{
-	dir = 8
-	},
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/green/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "agF" = (
 /obj/structure/flora/bush/grassy/style_4,
@@ -346,7 +342,7 @@
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -547,10 +543,9 @@
 	},
 /area/centcom/holding/cafepark)
 "alb" = (
-/obj/structure/flora/grass/jungle/a/style_3,
 /obj/structure/flora/bush/flowers_br,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ald" = (
 /turf/open/indestructible/cobble/corner{
@@ -590,9 +585,7 @@
 /obj/structure/flora/grass/jungle,
 /mob/living/basic/rabbit,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "alx" = (
 /obj/machinery/door/airlock/centcom{
@@ -717,8 +710,8 @@
 	},
 /area/centcom/holding/cafepark)
 "amk" = (
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "amu" = (
 /obj/structure/stone_tile/block{
@@ -859,9 +852,7 @@
 /obj/structure/flora/grass/jungle/a/style_3,
 /obj/structure/flora/bush/flowers_pp,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "anL" = (
 /obj/structure/table/wood,
@@ -874,6 +865,9 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/railing,
 /obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aoq" = (
@@ -1121,8 +1115,8 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aqV" = (
-/obj/structure/flora/grass/jungle/a/style_5,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/bush/snow/style_5,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aqX" = (
 /obj/effect/turf_decal/delivery,
@@ -1461,8 +1455,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
 "avt" = (
-/obj/structure/flora/grass/jungle/a/style_2,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/tree/pine/style_3{
+	step_x = 15;
+	step_y = -7
+	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "avu" = (
 /obj/vehicle/ridden/janicart/upgraded,
@@ -1620,7 +1617,7 @@
 /area/centcom/holding/cafe)
 "axA" = (
 /obj/structure/chair/sofa/bench/left,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "axB" = (
 /obj/structure/chair/sofa/bench{
@@ -1631,9 +1628,7 @@
 "axC" = (
 /obj/structure/flora/grass/jungle/b/style_5,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "axD" = (
 /obj/structure/curtain,
@@ -2219,7 +2214,7 @@
 	dir = 1;
 	name = "Jim Norton's Quebecois Coffee stool"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aCF" = (
 /obj/machinery/button/curtain{
@@ -2946,9 +2941,9 @@
 /area/centcom/holding/cafe)
 "aMG" = (
 /obj/structure/fans/tiny/invisible,
-/obj/structure/flora/grass/jungle/b,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/bush/snow/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aMJ" = (
 /obj/structure/flora/tree/jungle,
@@ -3200,6 +3195,9 @@
 /area/centcom/holding/cafe)
 "aOz" = (
 /obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aOG" = (
@@ -3466,6 +3464,9 @@
 /area/centcom/interlink)
 "aRd" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aRe" = (
@@ -3716,6 +3717,9 @@
 /area/centcom/holding/cafepark)
 "aTv" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aTB" = (
@@ -3749,8 +3753,11 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "aTG" = (
-/obj/structure/flora/grass/jungle/b/style_5,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aTR" = (
 /obj/structure/spacevine{
@@ -4186,10 +4193,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe)
-"aZs" = (
-/obj/structure/flora/rock/pile/jungle/style_2,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "aZz" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -4388,6 +4391,10 @@
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"bkt" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "bkA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -4696,9 +4703,7 @@
 	icon_state = "bush3"
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "bIf" = (
 /obj/machinery/biogenerator{
@@ -4755,7 +4760,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "bNh" = (
 /obj/structure/chair/sofa/bench{
@@ -5070,7 +5075,8 @@
 /area/centcom/interlink)
 "cgU" = (
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/bush/snow/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "che" = (
 /obj/effect/light_emitter/interlink,
@@ -5582,6 +5588,10 @@
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "dbn" = (
@@ -5650,6 +5660,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafepark)
 "djn" = (
@@ -6032,10 +6043,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafe)
-"dXe" = (
-/obj/structure/flora/grass/jungle/b/style_2,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "dXJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -6184,9 +6191,7 @@
 /obj/structure/flora/grass/jungle/b/style_5,
 /mob/living/basic/rabbit,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "esx" = (
 /obj/effect/decal/cleanable/xenoblood,
@@ -6955,9 +6960,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_pp,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "fOv" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
@@ -7180,8 +7183,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "gko" = (
-/obj/structure/flora/grass/jungle/a/style_4,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/green/style_3,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "gmD" = (
 /obj/structure/stone_tile/slab,
@@ -7302,8 +7305,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "gsX" = (
-/obj/structure/flora/rock/pile/jungle/large/style_2,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "gtO" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -7372,10 +7378,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "gyS" = (
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/obj/structure/flora/grass/green/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "gzT" = (
 /obj/structure/fake_stairs/wood/directional/north,
@@ -7536,6 +7540,10 @@
 "gSD" = (
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"gTx" = (
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "gUi" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/white,
@@ -7551,11 +7559,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/holding/cafe)
-"gVD" = (
-/obj/machinery/light/directional/east,
-/obj/structure/flora/bush/jungle/b,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "gWk" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -8218,6 +8221,11 @@
 /obj/structure/chair/sofa/left/brown,
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"ids" = (
+/obj/machinery/light/directional/north,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "iel" = (
 /obj/effect/turf_decal/nova_decals/misc/handicapped,
 /turf/open/floor/wood/tile,
@@ -8277,8 +8285,8 @@
 /turf/open/floor/sepia,
 /area/centcom/holding/cafe)
 "iho" = (
-/obj/structure/flora/grass/jungle/b/style_4,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/brown/style_3,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ijv" = (
 /obj/machinery/modular_computer/preset/command,
@@ -8429,9 +8437,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "iqT" = (
-/obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_yw,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "iqY" = (
 /obj/structure/flora/bush/sparsegrass,
@@ -8466,9 +8473,7 @@
 /obj/structure/flora/tree/jungle/style_2,
 /obj/structure/flora/grass/jungle,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "iuy" = (
 /obj/structure/disposalpipe/segment,
@@ -8603,8 +8608,8 @@
 /area/centcom/holding/cafepark)
 "iHv" = (
 /obj/structure/fans/tiny/invisible,
-/obj/structure/flora/grass/jungle/a/style_4,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/green/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "iIb" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -8622,8 +8627,11 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "iJK" = (
-/obj/structure/flora/bush/jungle/a,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "iJX" = (
 /obj/structure/chair/sofa/bench/right{
@@ -8838,9 +8846,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_yw,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "jdW" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -8899,6 +8905,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafepark)
 "jgT" = (
@@ -9628,6 +9635,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
+"kGY" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/flora/bush/snow/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "kHi" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -9776,7 +9788,7 @@
 /obj/structure/chair/stool/directional/south{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kMV" = (
 /obj/structure/flora/biolumi/flower{
@@ -10516,7 +10528,7 @@
 	pixel_x = 4;
 	pixel_y = 10
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "lXk" = (
 /obj/item/flashlight/lantern,
@@ -10689,9 +10701,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "mon" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/flora/bush/jungle/b,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/tree/dead/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "moG" = (
 /obj/item/kirbyplants/organic/plant22,
@@ -10824,6 +10835,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"mxL" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/flora/grass/both/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "mza" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -10877,9 +10893,7 @@
 "mBs" = (
 /obj/structure/flora/grass/jungle/a/style_5,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "mBM" = (
 /obj/structure/table/rolling,
@@ -11157,9 +11171,7 @@
 /obj/structure/flora/tree/jungle/small/style_random,
 /obj/structure/flora/grass/jungle,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "mZu" = (
 /obj/structure/closet/emcloset,
@@ -11324,8 +11336,7 @@
 /obj/structure/chair/stool{
 	name = "Jim Norton's Quebecois Coffee stool"
 	},
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "nlM" = (
 /obj/structure/curtain,
@@ -11629,7 +11640,7 @@
 	name = "Jim Norton's Quebecois Coffee table"
 	},
 /obj/item/reagent_containers/cup/glass/mug/coco,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "nPs" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
@@ -11672,7 +11683,13 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/interlink)
 "nUS" = (
-/obj/structure/flora/grass/jungle/a/style_2,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "nVZ" = (
@@ -11903,9 +11920,8 @@
 /turf/open/floor/carpet/black,
 /area/centcom/holding/cafe)
 "ooY" = (
-/obj/structure/flora/grass/jungle/a/style_4,
 /obj/structure/chair/sofa/bench/right,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "orh" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -11971,9 +11987,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "ovF" = (
-/obj/structure/fans/tiny/invisible,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/both/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ovH" = (
 /obj/machinery/vending/wardrobe/syndie_wardrobe{
@@ -11982,6 +11997,12 @@
 	fair_market_price = 0
 	},
 /turf/open/misc/dirt/planet,
+/area/centcom/holding/cafepark)
+"owC" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/light_emitter/interlink,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "owJ" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
@@ -12101,9 +12122,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "oAt" = (
-/obj/structure/flora/grass/jungle/a/style_4,
-/obj/structure/fans/tiny/invisible,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/tree/pine/style_3,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "oBa" = (
 /obj/structure/stone_tile/center,
@@ -12167,6 +12187,11 @@
 /turf/open/indestructible/hoteltile{
 	icon_state = "darkfull"
 	},
+/area/centcom/holding/cafepark)
+"oIy" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "oIK" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
@@ -12356,12 +12381,9 @@
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafepark)
 "oVT" = (
-/obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "oWR" = (
 /obj/structure/fake_stairs/wood/directional/north,
@@ -12511,6 +12533,10 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/centcom/holding/cafe)
+"pgl" = (
+/obj/structure/flora/tree/pine/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "pgm" = (
 /obj/structure/hedge/opaque,
 /obj/structure/railing{
@@ -12594,6 +12620,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
+/obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafepark)
 "pmI" = (
@@ -12628,11 +12655,13 @@
 /turf/open/floor/grass,
 /area/centcom/interlink)
 "ppd" = (
-/obj/structure/flora/tree/jungle/small/style_random{
-	pixel_x = -49;
-	pixel_y = -12
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
 	},
-/turf/open/misc/grass/planet,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "ppR" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12700,9 +12729,7 @@
 "pux" = (
 /obj/structure/flora/bush/jungle/c/style_2,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "pwO" = (
 /obj/structure/chair/sofa/bench/corner{
@@ -12765,6 +12792,10 @@
 	},
 /turf/closed/indestructible/fakeglass,
 /area/centcom/holding/cafedorms)
+"pAF" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "pBj" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -12774,9 +12805,8 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "pBW" = (
-/obj/machinery/light/directional/south,
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/both/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "pCd" = (
 /turf/closed/wall/mineral/wood/nonmetal,
@@ -13109,9 +13139,8 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "pUQ" = (
-/obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_br,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "pVh" = (
 /obj/machinery/photocopier,
@@ -13270,17 +13299,34 @@
 "qhl" = (
 /obj/structure/flora/bush/large/style_2,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "qhn" = (
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"qhV" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/warning/cold_temp/directional/south{
+	desc = "A sign that warns of mildly cold air in the vicinity."
+	},
+/turf/open/indestructible/hoteltile{
+	icon_state = "floor"
+	},
+/area/centcom/holding/cafepark)
 "qiI" = (
 /obj/machinery/light/directional/south,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "qjh" = (
 /obj/structure/chair/sofa/bench/right{
@@ -13378,9 +13424,7 @@
 "qnH" = (
 /obj/structure/flora/grass/jungle/b/style_2,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "qot" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -13526,7 +13570,7 @@
 /obj/structure/chair/stool/directional/south{
 	dir = 8
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "qAW" = (
 /obj/effect/turf_decal/siding/white{
@@ -13536,7 +13580,7 @@
 /area/centcom/interlink)
 "qBd" = (
 /obj/machinery/light/directional/west,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "qBC" = (
 /obj/machinery/vending/primitive_catgirl_clothing_vendor,
@@ -13997,9 +14041,8 @@
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "roh" = (
-/obj/structure/flora/grass/jungle/a/style_3,
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "rpX" = (
 /obj/machinery/light/directional/south,
@@ -14016,9 +14059,7 @@
 "rvn" = (
 /obj/structure/flora/grass/jungle/b/style_4,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "rvt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -14353,6 +14394,12 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"rTf" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "rTv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -14952,6 +14999,10 @@
 	icon_state = "darkfull"
 	},
 /area/centcom/holding/cafepark)
+"sLB" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "sMF" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/machinery/firealarm/directional/south,
@@ -15057,9 +15108,8 @@
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
 "sUC" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/flora/grass/jungle/a/style_3,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/both/style_3,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "sUE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -15452,6 +15502,11 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"tDa" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "tDj" = (
 /obj/structure/rack/shelf{
 	icon = 'modular_nova/modules/mapping/icons/unique/furniture.dmi';
@@ -15507,11 +15562,6 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
-"tIM" = (
-/obj/structure/flora/bush/jungle/b,
-/obj/structure/fans/tiny/invisible,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "tIN" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -16223,7 +16273,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "uXH" = (
 /obj/structure/table/wood,
@@ -16311,9 +16361,7 @@
 "vdW" = (
 /obj/structure/flora/bush/jungle/b,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "veh" = (
 /obj/structure/fence/door,
@@ -16716,8 +16764,12 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "vXr" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "vYz" = (
 /obj/machinery/button/curtain{
@@ -16884,9 +16936,13 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/interlink)
 "wjI" = (
-/obj/structure/flora/grass/jungle/a/style_2,
-/obj/machinery/light/directional/north,
-/turf/open/misc/grass/planet,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "wkG" = (
 /obj/structure/chair/stool/bar/directional/south,
@@ -16930,9 +16986,12 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "wns" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/flora/grass/jungle/b,
-/turf/open/misc/grass/planet,
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "wod" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -17369,9 +17428,7 @@
 "xbn" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "xct" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -17567,6 +17624,11 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"xtR" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/flora/grass/brown/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/holding/cafepark)
 "xuk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair/sofa/bench{
@@ -17601,9 +17663,8 @@
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
 "xyn" = (
-/obj/structure/flora/grass/jungle/a/style_4,
 /obj/machinery/light/directional/north,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "xyz" = (
 /obj/structure/closet/crate/bin,
@@ -17952,8 +18013,8 @@
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "ybu" = (
-/obj/structure/flora/rock/pile/jungle/style_3,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/bush/snow/style_6,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ybB" = (
 /obj/item/kirbyplants/random,
@@ -17971,9 +18032,8 @@
 /turf/open/floor/sepia,
 /area/centcom/holding/cafe)
 "ybS" = (
-/obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_pp,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ybX" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -18021,9 +18081,7 @@
 "yde" = (
 /obj/structure/flora/bush/jungle/a,
 /obj/effect/light_emitter/interlink,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ydt" = (
 /obj/effect/landmark/latejoin,
@@ -66513,7 +66571,7 @@ vzb
 pit
 ufE
 qdG
-vdW
+roh
 bUS
 anz
 apT
@@ -66770,18 +66828,18 @@ dzn
 sUE
 jtc
 oVT
-axC
-gyS
+roh
+roh
 nWn
 kJw
 dhi
-avt
+izJ
 bLZ
 uXF
 uXF
 afN
 pUQ
-aNk
+gyS
 vTT
 saT
 aVg
@@ -67026,19 +67084,19 @@ aIr
 nMw
 sUE
 jtc
-pux
+roh
 qhl
-qnH
+roh
 nWn
 qVU
 pkJ
 iqT
-aqV
-dXe
-aFP
-aFP
-kWr
-aqV
+lgt
+aiD
+aiD
+aiD
+aDB
+gTx
 vTT
 cxU
 nyj
@@ -67283,19 +67341,19 @@ ddp
 aWP
 sIZ
 jtc
-gyS
+roh
 mZp
 yde
 nWn
 qVU
 qUK
-ayI
-aOz
-ayI
-ayI
-aOz
-ayI
-pBW
+ppd
+gsX
+pib
+pib
+gsX
+nzn
+qiI
 aAv
 vTT
 vTT
@@ -67544,15 +67602,15 @@ mBs
 bHC
 anD
 nWn
-qVU
+qhV
 pkJ
-avt
-kWr
-aFP
-kWr
-aFP
-ayI
-ayI
+aAd
+gTx
+aAd
+gTx
+bkt
+aCX
+aiD
 rCf
 tbI
 aye
@@ -67803,13 +67861,13 @@ axC
 nWn
 kJq
 jgG
-iJK
+ovF
 nlB
 ahI
 aCw
-kWr
-ayI
-ayI
+aAd
+aCX
+pib
 rCf
 gnv
 hTD
@@ -68056,16 +68114,16 @@ nlv
 jtc
 yde
 erR
-oVT
+owC
 nWn
 hOy
 ekp
 aTv
-nUS
-aFP
-aFP
-aFP
-ayI
+aDB
+gyS
+aAd
+izJ
+aoE
 qiI
 aAv
 xTZ
@@ -68320,9 +68378,9 @@ vTT
 mwo
 kWb
 gzT
-ayI
-ayI
-ayI
+tMb
+tMb
+nzn
 kMw
 aZq
 lNi
@@ -68578,8 +68636,8 @@ bVx
 aUo
 xoB
 kMw
-aFP
-aOz
+aAd
+wns
 lWZ
 aZq
 aCY
@@ -68835,8 +68893,8 @@ feU
 aUo
 nng
 nPr
-aFP
-ayI
+izJ
+aoE
 qAg
 vTT
 gmE
@@ -69091,10 +69149,10 @@ vTT
 foq
 awv
 aer
-agA
-kWr
-ayI
-kWr
+qAg
+aAd
+aoE
+aAd
 vTT
 vTT
 vTT
@@ -69339,7 +69397,7 @@ aIr
 tvh
 sUE
 alW
-oVT
+owC
 alo
 qnH
 nWn
@@ -69349,10 +69407,10 @@ vTT
 vTT
 vTT
 vTT
-aqV
-ayI
-aqV
-aFP
+pAF
+aoE
+aAd
+izJ
 vTT
 sYY
 ski
@@ -69598,7 +69656,7 @@ sUE
 alW
 yde
 bHC
-gyS
+roh
 nWn
 apT
 vTT
@@ -69606,10 +69664,10 @@ bBV
 saT
 rNs
 vTT
-aqV
-ayI
+gTx
+aoE
 iqT
-aFP
+aAd
 vTT
 jDo
 qWv
@@ -69855,7 +69913,7 @@ gRb
 alW
 qnH
 pux
-gyS
+roh
 nWn
 rkW
 vTT
@@ -69863,10 +69921,10 @@ xIx
 adu
 aUo
 rYj
-ayI
-ayI
-kWr
-aFP
+ppd
+nzn
+aAd
+agA
 vTT
 mGn
 dOM
@@ -70120,10 +70178,10 @@ aHM
 aUo
 aUo
 vTT
-kWr
-aOz
-aFP
-aFP
+izJ
+wns
+izJ
+aAd
 vTT
 qoG
 yaL
@@ -70377,10 +70435,10 @@ kpY
 qFt
 awr
 vTT
-wjI
-ayI
-aFP
-kWr
+xyn
+aoE
+bkt
+aAd
 vTT
 vTT
 vTT
@@ -70635,16 +70693,16 @@ vTT
 vTT
 vTT
 amk
-ayI
-aFP
-kWr
-aFP
-kWr
+aoE
+gko
+aAd
+pBW
+oAt
 ybS
-kWr
-aFP
-kWr
-aFP
+aAd
+aAd
+izJ
+aqV
 vTT
 vTT
 vTT
@@ -70891,21 +70949,21 @@ mCv
 dRI
 noy
 vTT
-aKu
-ayI
-kWr
+pAF
+aoE
+ovF
 gko
-kWr
-aFP
-aFP
-kWr
-cgU
-aFP
-aFP
-iho
-kWr
+aAd
+aAd
+aAd
+izJ
+roh
+aAd
+aAd
+aAd
+izJ
 qBd
-aFP
+aAd
 vTT
 ajj
 pCd
@@ -71149,20 +71207,20 @@ aUo
 aII
 vTT
 aqV
-ayI
-aOz
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-aFP
-aFP
-aFP
-amk
-aFP
-kWr
+aCX
+iJK
+aiD
+aiD
+aiD
+aiD
+aiD
+aDB
+pBW
+aAd
+mon
+aAd
+izJ
+aAd
 vTT
 ajj
 amx
@@ -71405,21 +71463,21 @@ awv
 awv
 aAq
 vTT
-kWr
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-aFP
-aFP
-dXe
-aFP
-ybu
+agA
+aCX
+pib
+pib
+pib
+pib
+pib
+pib
+pib
+aDB
+aAd
+izJ
+pAF
+gTx
+aAd
 vTT
 vTT
 vTT
@@ -71662,23 +71720,23 @@ doA
 doA
 doA
 fUQ
-ayI
-ayI
+tMb
+eNw
 ybS
-dXe
-aTG
-aFP
-dXe
-aFP
-aFP
-aOz
-kWr
-aFP
-aFP
-kWr
-aKu
-kWr
-aaY
+aAd
+pAF
+izJ
+aqV
+aAd
+iho
+vXr
+gko
+aAd
+izJ
+bkt
+ovF
+izJ
+iHv
 qNZ
 vTT
 aUd
@@ -71919,23 +71977,23 @@ doA
 doA
 lij
 vTT
-aFP
-aFP
-kWr
-aFP
+izJ
+aAd
+aAd
+izJ
 cgU
-gsX
-kWr
-kWr
-aFP
-ayI
-ayI
-ayI
-ayI
-aFP
-cgU
-aFP
-aaY
+aAd
+aAd
+amk
+aAd
+aSZ
+tMb
+aiD
+aDB
+izJ
+roh
+aAd
+iHv
 uoM
 vTT
 ycB
@@ -72180,18 +72238,18 @@ mZu
 jgg
 wvy
 iho
-aTG
-iho
-gVD
+aAd
+mon
+aAd
 ybu
-kWr
-gko
-kWr
-aOz
-ayI
-kWr
-kWr
-aaY
+izJ
+sLB
+ovF
+aTG
+nzn
+sUC
+sLB
+mxL
 uoM
 uoM
 vTT
@@ -72441,14 +72499,14 @@ vTT
 vTT
 vTT
 vTT
-iJK
-pUQ
-kWr
-kWr
-ayI
-ayI
-pUQ
-oAt
+aAd
+aAd
+aAd
+pAF
+wjI
+aDB
+izJ
+xtR
 uoM
 kso
 vTT
@@ -72698,13 +72756,13 @@ xXU
 ewl
 gmU
 vTT
-gko
-aNk
+bkt
+gyS
 avt
 ooY
-aFP
+aAd
 dav
-oAt
+xtR
 uoM
 uoM
 uoM
@@ -72955,16 +73013,16 @@ qWG
 arh
 aXF
 vTT
-aFP
-avt
-ppd
+ovF
+aAd
+aAd
 axA
-kWr
+aAd
 anQ
 uoM
 uoM
 uoM
-aaY
+iHv
 vTT
 vTT
 hge
@@ -73212,19 +73270,19 @@ bYx
 arh
 arh
 skM
-ayI
-ayI
-aFP
-kWr
-ayI
+tMb
+aDB
+tDa
+bkt
+lgt
 blD
 uoM
 uoM
-aaY
-gko
-aFP
+mxL
+aAd
+izJ
 qBd
-ayI
+aCX
 ekp
 aUm
 aUm
@@ -73469,18 +73527,18 @@ arh
 arh
 oPL
 vTT
-xyn
-ayI
-aOz
-ayI
-ayI
+ids
+aSZ
+nUS
+tMb
+pib
 mYy
 ppR
 bSf
 dNB
 aOz
-ayI
-ayI
+aiD
+aiD
 ayI
 sFF
 aUm
@@ -73726,18 +73784,18 @@ arh
 arh
 qmG
 vTT
-aKu
-avt
-gko
-kWr
-vXr
+ovF
+aAd
+gyS
+aAd
+aAd
+mxL
+uoM
+uoM
 iHv
-uoM
-uoM
-oAt
-ayI
-ayI
-ayI
+aSZ
+pib
+pib
 ayI
 aNF
 aUm
@@ -73983,18 +74041,18 @@ vFM
 qUb
 xXU
 vTT
-avt
-amk
-pUQ
-aaY
+pgl
+ovF
+aAd
 iHv
+kGY
 uoM
 uoM
 uoM
-tIM
-pUQ
-gko
-kWr
+xtR
+aAd
+gTx
+gyS
 aRd
 ekp
 aUm
@@ -74240,18 +74298,18 @@ uMR
 xfD
 qWG
 vTT
-aaY
-aaY
-ovF
+kGY
+iHv
+rTf
 uoM
 uoM
 uoM
 uoM
-aaY
-vXr
-vXr
-vXr
-aFP
+iHv
+aAd
+aAd
+pgl
+aAd
 ekp
 ekp
 aUm
@@ -74504,10 +74562,10 @@ uoM
 uoM
 uoM
 uoM
-ovF
-aFP
-vXr
-aFP
+aMG
+gTx
+gyS
+aAd
 ekp
 ekp
 aUm
@@ -74760,9 +74818,9 @@ uoM
 qNZ
 uoM
 aMG
-wns
-aFP
-aFP
+iHv
+pgl
+izJ
 ekp
 ekp
 ekp
@@ -75014,12 +75072,12 @@ vTT
 ekp
 ekp
 ekp
-mon
-sUC
-vXr
-gko
-vXr
-aZs
+kGY
+oIy
+gTx
+aAd
+aAd
+gTx
 ekp
 aUm
 aUm
@@ -75271,9 +75329,9 @@ ajj
 ajj
 ajj
 ekp
-ekp
-roh
-iJK
+gyS
+izJ
+aAd
 alb
 ekp
 ekp

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -33,7 +33,7 @@
 /area/centcom/holding/cafe)
 "aaY" = (
 /obj/structure/fans/tiny/invisible,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "abK" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -129,7 +129,7 @@
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "fullgrass_3"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aeW" = (
 /obj/effect/turf_decal/tile/green,
@@ -189,7 +189,7 @@
 /area/centcom/holding/cafe)
 "afA" = (
 /obj/structure/flora/grass/green,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "afB" = (
 /obj/structure/flora/bush/ferny{
@@ -256,17 +256,13 @@
 /obj/machinery/vending/access/command,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
-"agy" = (
-/obj/structure/flora/bush/leafy,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "agA" = (
 /obj/structure/flora/grass/green/style_2,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "agF" = (
 /obj/structure/flora/bush/grassy/style_4,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "agG" = (
 /obj/effect/turf_decal/tile/blue{
@@ -302,7 +298,7 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "agV" = (
 /obj/structure/closet/wardrobe/grey,
@@ -315,13 +311,13 @@
 /area/centcom/holding/cafepark)
 "ahs" = (
 /obj/structure/flora/bush/leavy/style_2,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahA" = (
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/pointy,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahG" = (
 /obj/structure/rack,
@@ -364,11 +360,11 @@
 /area/centcom/holding/cafe)
 "ahQ" = (
 /obj/structure/flora/bush/sparsegrass,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahU" = (
 /obj/structure/flora/bush/large,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahY" = (
 /obj/structure/chair/sofa/corp/right{
@@ -473,7 +469,7 @@
 /obj/structure/flora/rock/pile{
 	icon_state = "basalt3"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ajR" = (
 /obj/structure/flora/rock/pile{
@@ -517,7 +513,7 @@
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/flora/bush/lavendergrass,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aks" = (
 /obj/structure/chair/sofa/corp/left{
@@ -555,7 +551,7 @@
 "alf" = (
 /obj/structure/flora/bush/lavendergrass,
 /obj/structure/flora/bush/flowers_br,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "alk" = (
 /obj/effect/spawner/random/bedsheet/double,
@@ -582,8 +578,8 @@
 	},
 /area/centcom/holding/cafe)
 "alo" = (
-/obj/structure/flora/grass/jungle,
 /mob/living/basic/rabbit,
+/obj/structure/flora/tree/pine/style_3,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -617,7 +613,7 @@
 /area/centcom/holding/cafe)
 "alF" = (
 /obj/structure/flora/rock/pile,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "alH" = (
 /obj/structure/fans/tiny/invisible,
@@ -761,10 +757,6 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/holding/cafe)
-"amT" = (
-/obj/structure/flora/bush/flowers_br,
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
 "amU" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -846,12 +838,6 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
-"anD" = (
-/obj/structure/flora/grass/jungle/a/style_3,
-/obj/structure/flora/bush/flowers_pp,
-/obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "anL" = (
@@ -1181,7 +1167,7 @@
 /obj/structure/flora/bush/lavendergrass{
 	icon_state = "lavendergrass_3"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "asp" = (
 /obj/machinery/hydroponics/constructable,
@@ -1211,7 +1197,7 @@
 /area/centcom/holding/cafe)
 "asF" = (
 /obj/structure/flora/bush/flowers_pp/style_3,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "asP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1249,7 +1235,7 @@
 /obj/structure/flora/bush/lavendergrass{
 	icon_state = "lavendergrass_2"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "asY" = (
 /obj/structure/kitchenspike,
@@ -1327,16 +1313,7 @@
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "brflowers_2"
 	},
-/turf/open/misc/grass/planet,
-/area/centcom/holding/cafepark)
-"auf" = (
-/obj/structure/flora/biolumi/flower{
-	light_color = "#D9FF00";
-	light_power = 0.3;
-	light_range = 10;
-	random_light = null
-	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "auj" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -1420,7 +1397,7 @@
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass2gb"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "avl" = (
 /obj/structure/rack/wooden,
@@ -1553,7 +1530,7 @@
 	name = "thick vines";
 	opacity = 1
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "awW" = (
 /obj/structure/chair/sofa/bench/left{
@@ -1598,7 +1575,7 @@
 /area/centcom/holding/cafe)
 "axw" = (
 /obj/structure/flora/bush/leavy/style_3,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "axz" = (
 /obj/effect/turf_decal/tile/green,
@@ -1625,11 +1602,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"axC" = (
-/obj/structure/flora/grass/jungle/b/style_5,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "axD" = (
 /obj/structure/curtain,
 /obj/machinery/light/floor{
@@ -1699,7 +1671,7 @@
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass3gb"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aye" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -1821,7 +1793,7 @@
 /area/centcom/holding/cafe)
 "azk" = (
 /obj/structure/flora/tree/jungle/small,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "azl" = (
 /obj/effect/turf_decal/tile/green{
@@ -1882,8 +1854,9 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aAc" = (
-/obj/structure/flora/bush/flowers_pp,
-/turf/open/misc/grass/planet,
+/obj/structure/flora/grass/brown/style_3,
+/obj/effect/light_emitter/interlink,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aAd" = (
 /turf/open/misc/asteroid/snow/indestructible/planet,
@@ -1976,7 +1949,7 @@
 /area/centcom/holding/cafe)
 "aAz" = (
 /obj/structure/flora/bush/jungle/a/style_3,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aAC" = (
 /obj/structure/fluff/tram_rail/end{
@@ -2108,13 +2081,13 @@
 	icon_state = "lavendergrass_4"
 	},
 /obj/structure/flora/bush/sparsegrass,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aBr" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/flowers_yw,
 /obj/structure/flora/bush/sunny,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aBs" = (
 /obj/effect/turf_decal/tile/blue{
@@ -2232,12 +2205,12 @@
 /area/centcom/interlink)
 "aCM" = (
 /obj/structure/flora/bush/flowers_pp/style_2,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aCQ" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/railing/wooden_fencing,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aCR" = (
 /obj/item/hilbertshotel/ghostdojo,
@@ -2247,11 +2220,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/vox,
 /area/centcom/holding/cafevox)
-"aCU" = (
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
-/area/centcom/holding/cafepark)
 "aCX" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -2426,13 +2394,13 @@
 /area/centcom/holding/cafe)
 "aFB" = (
 /obj/structure/flora/bush/ferny,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aFI" = (
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree6"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aFK" = (
 /obj/structure/table/optable,
@@ -2447,20 +2415,22 @@
 	},
 /area/centcom/holding/cafe)
 "aFP" = (
-/turf/open/misc/grass/planet,
+/obj/structure/fans/tiny/invisible,
+/obj/structure/bonfire/prelit,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aFV" = (
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "fullgrass_2"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aGb" = (
 /turf/closed/indestructible/riveted/boss,
 /area/centcom/holding/cafepark)
 "aGg" = (
 /obj/structure/flora/bush/large/style_2,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aGk" = (
 /obj/machinery/bookbinder,
@@ -2719,7 +2689,7 @@
 /obj/structure/flora/bush/fullgrass{
 	icon_state = "brflowers_1"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aII" = (
 /obj/structure/chair/comfy/barber_chair{
@@ -2742,7 +2712,7 @@
 /obj/structure/flora/bush/lavendergrass{
 	icon_state = "lavendergrass_4"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aJh" = (
 /turf/open/misc/beach/sand{
@@ -2824,7 +2794,7 @@
 /area/centcom/holding/cafe)
 "aKu" = (
 /obj/structure/flora/bush/jungle/b,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aKA" = (
 /obj/structure/chair/sofa/corp/right,
@@ -2885,7 +2855,7 @@
 /area/centcom/holding/cafe)
 "aLH" = (
 /obj/structure/flora/bush/fullgrass,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aLO" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -2947,7 +2917,7 @@
 /area/centcom/holding/cafepark)
 "aMJ" = (
 /obj/structure/flora/tree/jungle,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aMM" = (
 /obj/machinery/computer/security,
@@ -2975,7 +2945,7 @@
 /obj/structure/flora/grass/green{
 	icon_state = "snowgrass1bb"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aNd" = (
 /obj/structure/table/wood,
@@ -3047,7 +3017,7 @@
 /obj/structure/flora/bush/large{
 	icon_state = "bush3"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aNp" = (
 /obj/structure/stone_tile/block,
@@ -3084,7 +3054,7 @@
 "aNB" = (
 /obj/structure/flora/bush/leavy/style_3,
 /obj/structure/flora/tree/jungle,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aNF" = (
 /obj/structure/fans/tiny/invisible,
@@ -3300,7 +3270,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aPG" = (
 /obj/structure/sink/kitchen/directional/east,
@@ -3358,7 +3328,7 @@
 "aQw" = (
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aQx" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -3571,7 +3541,7 @@
 	light_range = 10;
 	random_light = null
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aRS" = (
 /turf/open/misc/beach/coast/corner{
@@ -3637,7 +3607,7 @@
 /obj/structure/flora/tree/jungle/small{
 	icon_state = "tree4"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aSt" = (
 /obj/effect/turf_decal/sand,
@@ -3713,7 +3683,7 @@
 /area/centcom/holding/cafepark)
 "aTu" = (
 /obj/structure/flora/bush/grassy/style_2,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aTv" = (
 /obj/structure/closet/crate/bin,
@@ -3913,7 +3883,7 @@
 /area/centcom/holding/cafepark)
 "aVA" = (
 /obj/structure/flora/bush/generic,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aVC" = (
 /obj/machinery/shower/directional/west,
@@ -3955,7 +3925,7 @@
 /area/centcom/holding/cafepark)
 "aWj" = (
 /obj/structure/flora/bush/grassy/style_3,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aWo" = (
 /obj/structure/spacevine{
@@ -3988,9 +3958,8 @@
 /area/centcom/holding/cafe)
 "aWy" = (
 /obj/structure/flora/bush/flowers_pp,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/obj/effect/light_emitter/interlink,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aWL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -4376,7 +4345,7 @@
 /obj/structure/railing/wooden_fencing{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "bjh" = (
 /obj/structure/chair/sofa/bench/left{
@@ -4699,9 +4668,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "bHC" = (
-/obj/structure/flora/bush/large{
-	icon_state = "bush3"
-	},
+/obj/structure/flora/grass/green/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -6188,8 +6155,8 @@
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
 "erR" = (
-/obj/structure/flora/grass/jungle/b/style_5,
 /mob/living/basic/rabbit,
+/obj/structure/flora/grass/green/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -6957,8 +6924,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/holding/cafe)
 "fOu" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_pp,
+/obj/structure/flora/tree/pine/xmas,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -7238,7 +7204,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "gqq" = (
 /obj/structure/railing{
@@ -7820,7 +7786,7 @@
 /area/centcom/holding/cafepark)
 "hpP" = (
 /mob/living/basic/butterfly,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "hpR" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -7951,7 +7917,7 @@
 /area/centcom/interlink)
 "hBy" = (
 /obj/structure/flora/tree/jungle/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "hEK" = (
 /obj/structure/railing/corner{
@@ -8155,7 +8121,7 @@
 	},
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/chair/wood,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "hXd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -8469,12 +8435,6 @@
 /obj/machinery/light/cold/no_nightlight/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/interlink)
-"itm" = (
-/obj/structure/flora/tree/jungle/style_2,
-/obj/structure/flora/grass/jungle,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "iuy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -8843,7 +8803,6 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafepark)
 "jdx" = (
-/obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_yw,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
@@ -9429,9 +9388,7 @@
 	light_range = 10;
 	random_light = null
 	},
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "khz" = (
 /obj/structure/chair/sofa/bench/right,
@@ -9560,7 +9517,7 @@
 "kuV" = (
 /obj/structure/flora/bush/leavy/style_2,
 /obj/structure/flora/tree/jungle/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kvD" = (
 /obj/structure/sign/poster/random/directional/west,
@@ -9625,7 +9582,7 @@
 "kFE" = (
 /obj/structure/spacevine,
 /obj/structure/fans/tiny/invisible,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kGT" = (
 /obj/structure/fans/tiny/invisible,
@@ -9794,7 +9751,7 @@
 /obj/structure/flora/biolumi/flower{
 	random_light = null
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kNb" = (
 /obj/structure/disposalpipe/segment{
@@ -9847,7 +9804,7 @@
 /area/centcom/holding/cafepark)
 "kPK" = (
 /obj/structure/railing/wooden_fencing,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kQs" = (
 /obj/machinery/door/airlock/public/glass{
@@ -9887,7 +9844,7 @@
 /area/centcom/holding/cafe)
 "kWr" = (
 /obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "kWA" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -10555,7 +10512,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "mac" = (
 /obj/effect/turf_decal/siding/white{
@@ -10890,11 +10847,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"mBs" = (
-/obj/structure/flora/grass/jungle/a/style_5,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "mBM" = (
 /obj/structure/table/rolling,
 /obj/item/hhmirror{
@@ -10939,7 +10891,7 @@
 /obj/structure/railing/wooden_fencing{
 	dir = 8
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "mCv" = (
 /obj/structure/table/reinforced/rglass,
@@ -11168,8 +11120,7 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "mZp" = (
-/obj/structure/flora/tree/jungle/small/style_random,
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/pine/style_3,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -11999,8 +11950,7 @@
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "owC" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -12726,11 +12676,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
-"pux" = (
-/obj/structure/flora/bush/jungle/c/style_2,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "pwO" = (
 /obj/structure/chair/sofa/bench/corner{
 	dir = 4
@@ -13296,11 +13241,6 @@
 /obj/structure/stone_tile/surrounding,
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafepark)
-"qhl" = (
-/obj/structure/flora/bush/large/style_2,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "qhn" = (
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron/dark,
@@ -13422,7 +13362,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "qnH" = (
-/obj/structure/flora/grass/jungle/b/style_2,
+/obj/structure/flora/bush/snow/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -14057,7 +13997,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/interlink)
 "rvn" = (
-/obj/structure/flora/grass/jungle/b/style_4,
+/obj/structure/statue/snow/snowman,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -14235,7 +14175,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "rNs" = (
 /obj/structure/chair/office{
@@ -16015,7 +15955,7 @@
 /area/centcom/interlink)
 "uwP" = (
 /obj/structure/chair/wood,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "uxo" = (
 /obj/structure/disposalpipe/segment{
@@ -16359,13 +16299,13 @@
 	},
 /area/centcom/holding/cafe)
 "vdW" = (
-/obj/structure/flora/bush/jungle/b,
+/obj/structure/flora/grass/both/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "veh" = (
 /obj/structure/fence/door,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "vgs" = (
 /obj/structure/table/wood,
@@ -16546,9 +16486,7 @@
 /area/centcom/holding/cafe)
 "vyS" = (
 /obj/structure/flora/bush/leafy,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
-	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "vzb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -16738,7 +16676,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "vUI" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -16846,14 +16784,6 @@
 	},
 /turf/open/indestructible/hoteltile{
 	icon_state = "floor"
-	},
-/area/centcom/holding/cafepark)
-"wcd" = (
-/obj/structure/flora/bush/flowers_pp,
-/obj/structure/flora/bush/flowers_br,
-/obj/structure/flora/bush/lavendergrass,
-/turf/open/misc/grass/planet{
-	smoothing_flags = 0
 	},
 /area/centcom/holding/cafepark)
 "wcf" = (
@@ -17426,7 +17356,7 @@
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
 "xbn" = (
-/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/brown/style_random,
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
@@ -17763,7 +17693,7 @@
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "xFU" = (
 /obj/effect/turf_decal/sand,
@@ -17771,7 +17701,7 @@
 /area/centcom/holding/cafepark)
 "xFZ" = (
 /obj/structure/flora/bush/sunny,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "xGO" = (
 /obj/structure/railing{
@@ -18078,11 +18008,6 @@
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/white,
 /area/centcom/interlink)
-"yde" = (
-/obj/structure/flora/bush/jungle/a,
-/obj/effect/light_emitter/interlink,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "ydt" = (
 /obj/effect/landmark/latejoin,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -54741,21 +54666,21 @@ ajj
 ajj
 ajj
 ajj
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 axw
-auf
+kgI
 aAz
 aMW
-agy
+vyS
 ajj
 ajj
 ajj
 ajj
 ajj
-auf
+kgI
 ahs
 ajj
 ajj
@@ -54989,34 +54914,34 @@ ayI
 ayI
 ajj
 ajj
-aFP
+aAd
 ayd
 aLH
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 asF
 aMJ
 kPK
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 aLH
-aFP
+aAd
 aMJ
 aBr
-aFP
-aFP
+aAd
+aAd
 aMJ
-aFP
-aFP
+aAd
+aAd
 akp
-aFP
-aFP
+aAd
+aAd
 aeT
-aFP
+aAd
 asF
 ajj
 ajj
@@ -55247,35 +55172,35 @@ azs
 ajj
 aLH
 arT
-aFP
+aAd
 aBr
-aFP
+aAd
 avb
 aLH
-aFP
-aFP
+aAd
+aAd
 kPK
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 aVA
-aFP
+aAd
 aCM
 aeT
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aCM
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aLH
-aFP
+aAd
 hBy
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aMJ
 ajj
 ajj
@@ -55503,37 +55428,37 @@ aWo
 ajj
 ajj
 aCM
-auf
+kgI
 ahU
-aFP
+aAd
 aIV
 ahA
-aFP
+aAd
 ahQ
-aFP
+aAd
 kPK
-aFP
-auf
-aFP
-aFP
+aAd
+kgI
+aAd
+aAd
 aFB
 akp
 azk
-aFP
+aAd
 kWr
 aFB
-aFP
-aFP
+aAd
+aAd
 aVA
 aIV
 aNB
-aFP
+aAd
 aKu
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 anC
 ajj
 aCv
@@ -55761,37 +55686,37 @@ ajj
 ajK
 ahQ
 aLH
-aFP
+aAd
 axw
-aFP
+aAd
 aAz
 ahs
-aFP
-aAc
+aAd
+ybS
 kPK
-aFP
-aFP
-aFP
-aFP
-aFP
-agy
+aAd
+aAd
+aAd
+aAd
+aAd
+vyS
 aMJ
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
 aBr
 aCM
 aFV
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 ajj
 aUm
 cZJ
@@ -56015,39 +55940,39 @@ ayp
 aWo
 ajj
 ajj
-aFP
+aAd
 aAz
-aFP
+aAd
 axw
-aFP
+aAd
 aFB
-aFP
-auf
+aAd
+kgI
 ahQ
-aFP
+aAd
 kPK
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 ahU
-aFP
+aAd
 ayd
 aBp
 kWr
-aFP
+aAd
 rMZ
-aFP
+aAd
 kWr
 kWr
-aFP
+aAd
 arT
 ayd
-agy
-aFP
+vyS
+aAd
 aNk
-aFP
-aFP
+aAd
+aAd
 avb
 ajj
 ajj
@@ -56277,36 +56202,36 @@ aqf
 aqf
 aqf
 aqf
-aFP
+aAd
 aLH
-aFP
-aFP
+aAd
+aAd
 ayd
 kPK
 aKu
-aFP
-aFP
-agy
+aAd
+aAd
+vyS
 asX
 aLH
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 hWY
-hfJ
+aFP
 goK
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 akp
-aFP
+aAd
 alF
 asX
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aqf
 aqf
 aqf
@@ -56534,34 +56459,34 @@ nGL
 tzz
 orB
 aqf
-aFP
+aAd
 aBr
-aFP
+aAd
 arT
-aFP
+aAd
 aCQ
-aFP
-aFP
+aAd
+aAd
 ahs
 aeT
-aAc
-aFP
+ybS
+aAd
 kuV
-aFP
+aAd
 uwP
-aFP
+aAd
 aPC
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 aMJ
-aFP
-aFP
+aAd
+aAd
 aLH
-aAc
-aFP
-auf
+ybS
+aAd
+kgI
 ayI
 ayI
 aqf
@@ -56791,34 +56716,34 @@ ybQ
 ihd
 ihd
 aqf
-aFP
+aAd
 axw
-aFP
-aFP
+aAd
+aAd
 ahU
 kPK
 aIV
-aFP
-aFP
-aFP
-agy
+aAd
+aAd
+aAd
+vyS
 aFB
-aFP
+aAd
 aBr
-aFP
+aAd
 kWr
 lZn
 lZn
-aFP
-aFP
-aFP
-agy
+aAd
+aAd
+aAd
+vyS
 aeT
 ahs
 aMW
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 ayI
 ayI
 dWE
@@ -57048,34 +56973,34 @@ iBq
 ihd
 lLN
 aqf
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 kPK
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 azk
 aRP
 aNk
 arT
 aLH
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 aQw
 kWr
-aFP
+aAd
 alf
-aFP
+aAd
 aVA
-aFP
-agy
-aFP
+aAd
+vyS
+aAd
 ayI
 ayI
 aqf
@@ -57305,36 +57230,36 @@ aqf
 weP
 aqf
 aqf
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 xFZ
 kPK
-aFP
+aAd
 akp
-aFP
-aFP
+aAd
+aAd
 arT
 aFV
 avb
-aFP
+aAd
 ahQ
 aIE
 aNk
 asX
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aIV
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 akp
-aFP
-aFP
+aAd
+aAd
 ayI
-aFP
+aAd
 aqf
 aqf
 aqf
@@ -57562,36 +57487,36 @@ cmh
 gOS
 smx
 aqf
-aFP
-aFP
-aFP
-aFP
-auf
+aAd
+aAd
+aAd
+aAd
+kgI
 kPK
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aLH
-aFP
+aAd
 aMJ
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aMJ
-aFP
+aAd
 aVA
-aFP
-aFP
+aAd
+aAd
 azk
 aAz
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aMJ
-aFP
-aFP
+aAd
+aAd
 ayI
-aFP
+aAd
 aqf
 aRx
 aqf
@@ -57819,36 +57744,36 @@ qXC
 bAr
 agk
 kJU
-aFP
-aFP
+aAd
+aAd
 axw
-aFP
-aFP
+aAd
+aAd
 bja
-aFP
-aFP
+aAd
+aAd
 alF
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 asF
-aFP
+aAd
 aeT
 ayd
 aLH
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 asF
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 ayI
-aFP
+aAd
 aqf
 qWc
 axD
@@ -58087,25 +58012,25 @@ ayI
 aIV
 ahQ
 aFB
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aLH
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 aMJ
 agF
 atQ
-aFP
+aAd
 aFV
-aFP
+aAd
 afA
 ahU
-aFP
+aAd
 ayI
-aFP
+aAd
 aqf
 aqf
 aqf
@@ -58343,27 +58268,27 @@ ayI
 ayI
 ayI
 atQ
-aFP
+aAd
 aLH
-aFP
+aAd
 aWj
-auf
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
+kgI
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
 ahA
 alF
-aFP
-aFP
+aAd
+aAd
 aLH
 ahs
-aFP
+aAd
 ayI
-aFP
-auf
+aAd
+kgI
 aqf
 kkV
 aUo
@@ -58600,24 +58525,24 @@ ayI
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 azk
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aAz
 asF
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 azk
-agy
-aFP
-aFP
-aFP
+vyS
+aAd
+aAd
+aAd
 ayI
 ayI
 ayI
@@ -58847,37 +58772,37 @@ qXC
 qXC
 aIm
 oYO
-aFP
+aAd
 aLH
-aFP
-aAc
-auf
+aAd
+ybS
+kgI
 mCg
-aFP
-aFP
+aAd
+aAd
 ayI
 ayI
 ayI
 ayI
 ayI
-aFP
+aAd
 aLH
-aFP
+aAd
 aTu
 aBr
-aFP
-aFP
+aAd
+aAd
 aLH
-auf
-aFP
-aFP
+kgI
+aAd
+aAd
 aIV
-aFP
+aAd
 aVA
-aAc
+ybS
 ayI
-aFP
-aFP
+aAd
+aAd
 aqf
 aUo
 pqy
@@ -59104,34 +59029,34 @@ kJL
 riB
 iDL
 aqf
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 kPK
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 ayI
 ayI
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
 aIE
-aFP
-aFP
+aAd
+aAd
 axw
 aCM
 aGg
-aFP
+aAd
 aAz
 asX
-ayI
+aAd
 ayI
 ayd
 aMJ
@@ -59361,43 +59286,43 @@ bhQ
 bIO
 aqf
 aqf
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aSs
-aFP
+aAd
 lwv
 lwv
 lwv
 lwv
 lwv
 lwv
-aFP
+aAd
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-ayI
-ayI
-ayI
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
+ayI
+ayI
+ayI
+aAd
+aAd
+aAd
 axw
-aFP
+aAd
 axw
-aFP
-aFP
+aAd
+aAd
 atp
 atp
 atp
@@ -59618,11 +59543,11 @@ qXC
 jgt
 aSP
 aSP
-aFP
+aAd
 azk
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 lwv
 rHD
 wUS
@@ -59648,14 +59573,14 @@ ayI
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 kWr
-aFP
-aFP
+aAd
+aAd
 ajj
 ajj
 kFE
@@ -59901,8 +59826,8 @@ fFr
 akW
 akW
 sDY
-aFP
-aFP
+aAd
+aAd
 ayI
 ayI
 ayI
@@ -59910,16 +59835,16 @@ ayI
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 aFI
 axw
-aFP
-aFP
+aAd
+aAd
 axw
-aFP
-aFP
+aAd
+aAd
 aPf
 aPf
 aPf
@@ -60159,8 +60084,8 @@ qNu
 fFr
 wBV
 kWr
-aFP
-aFP
+aAd
+aAd
 ayI
 ayI
 ayI
@@ -60168,15 +60093,15 @@ ayI
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-agy
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+vyS
+aAd
 ayI
 ayI
 ayI
@@ -60415,24 +60340,24 @@ sen
 hfJ
 gqq
 wBV
-aFP
+aAd
 kWr
 kWr
-aFP
-aFP
-aFP
-auf
-aFP
+aAd
+aAd
+aAd
+kgI
+aAd
 ayI
 ayI
-aFP
-auf
-aFP
-aFP
-aFP
-aFP
-auf
-aFP
+aAd
+kgI
+aAd
+aAd
+aAd
+aAd
+kgI
+aAd
 ayI
 ayI
 ayI
@@ -60682,14 +60607,14 @@ aqf
 kWr
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 aMJ
-aFP
-aFP
+aAd
+aAd
 ayI
 ayI
 aPf
@@ -60936,19 +60861,19 @@ aWT
 aUo
 aBk
 aqf
-aFP
+aAd
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
+aAd
 ayI
 ayI
-aFP
+aAd
 aPf
 aPf
 aPf
@@ -61193,19 +61118,19 @@ aWT
 aUo
 aqO
 aqf
-aFP
+aAd
 ayI
 ayI
 ayI
-aFP
-aFP
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
+aAd
+aAd
 ayI
 ayI
-aFP
-aFP
+aAd
+aAd
 aPf
 aPf
 ajj
@@ -61461,8 +61386,8 @@ ayI
 ayI
 ayI
 ayI
-aFP
-aFP
+aAd
+aAd
 aPf
 aPf
 ajj
@@ -61966,18 +61891,18 @@ aGk
 aqf
 ayI
 ayI
-ayI
-aFP
+aAd
+aAd
 aMJ
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 ayI
 aWo
 ayI
 aPf
 aPf
-aFP
+aAd
 aPf
 ajj
 aaa
@@ -62223,18 +62148,18 @@ aqf
 aqf
 ayI
 ayI
-aFP
-auf
+aAd
+kgI
 kWr
-aFP
+aAd
 kWr
-aFP
-aFP
+aAd
+aAd
 aPf
 ayI
 aPf
-auf
-aFP
+kgI
+aAd
 aLH
 ajj
 aaa
@@ -62480,8 +62405,8 @@ aqf
 kWr
 ayI
 ayI
-aFP
-aFP
+aAd
+aAd
 aqf
 aqf
 aqf
@@ -62492,7 +62417,7 @@ ejQ
 aqf
 aqf
 aVA
-aFP
+aAd
 ajj
 aaa
 aaa
@@ -62994,7 +62919,7 @@ aqf
 ayI
 ayI
 ayI
-aFP
+aAd
 xFE
 aqf
 aHM
@@ -63005,8 +62930,8 @@ aUo
 aUo
 aUo
 iQp
-aFP
-aFP
+aAd
+aAd
 ajj
 aaa
 aaa
@@ -63248,11 +63173,11 @@ btN
 bcb
 ujV
 aqf
-auf
+kgI
 ayI
 ayI
-aFP
-aFP
+aAd
+aAd
 aqf
 aUo
 aUo
@@ -63263,7 +63188,7 @@ aUo
 aUo
 iQp
 hpP
-aFP
+aAd
 ajj
 aaa
 aaa
@@ -63508,7 +63433,7 @@ aqf
 aqf
 kWr
 ayI
-aFP
+aAd
 kWr
 aqf
 nii
@@ -63519,7 +63444,7 @@ bwG
 aUo
 aUo
 iQp
-aFP
+aAd
 aLH
 ajj
 aaa
@@ -63763,10 +63688,10 @@ paj
 fPs
 amF
 aqf
-aFP
+aAd
 ayI
-aFP
-aFP
+aAd
+aAd
 aqf
 sFB
 aUo
@@ -63776,8 +63701,8 @@ bwG
 aUo
 aCF
 aqf
-aAc
-auf
+ybS
+kgI
 ajj
 aaa
 aaa
@@ -64020,10 +63945,10 @@ xga
 amF
 amF
 aqf
-aFP
+aAd
 ayI
-aFP
-auf
+aAd
+kgI
 aqf
 aZW
 aUo
@@ -64277,10 +64202,10 @@ clF
 amF
 amF
 ahP
-aFP
+aAd
 ayI
 ayI
-aFP
+aAd
 aqf
 aYO
 aUo
@@ -64537,7 +64462,7 @@ aqf
 kWr
 ayI
 ayI
-aFP
+aAd
 aqf
 aqf
 aqf
@@ -64548,7 +64473,7 @@ aqf
 aqf
 aqf
 caY
-aWy
+ybS
 ajj
 aaa
 aaa
@@ -64805,7 +64730,7 @@ aqf
 tgU
 aMQ
 ozJ
-aCU
+aAd
 ajj
 ajj
 ajj
@@ -65318,7 +65243,7 @@ aqf
 aqf
 srA
 caY
-wcd
+akp
 aNk
 ajj
 ajj
@@ -66571,7 +66496,7 @@ vzb
 pit
 ufE
 qdG
-roh
+owC
 bUS
 anz
 apT
@@ -66829,7 +66754,7 @@ sUE
 jtc
 oVT
 roh
-roh
+owC
 nWn
 kJw
 dhi
@@ -67084,9 +67009,9 @@ aIr
 nMw
 sUE
 jtc
-roh
-qhl
-roh
+rvn
+vdW
+owC
 nWn
 qVU
 pkJ
@@ -67341,9 +67266,9 @@ ddp
 aWP
 sIZ
 jtc
-roh
+owC
 mZp
-yde
+bHC
 nWn
 qVU
 qUK
@@ -67580,8 +67505,8 @@ aPf
 aWo
 aWo
 aPf
-aFP
-aFP
+aAd
+aAd
 asX
 agU
 gtO
@@ -67598,9 +67523,9 @@ aIr
 nMw
 sUE
 jtc
-mBs
 bHC
-anD
+bHC
+roh
 nWn
 qhV
 pkJ
@@ -67837,9 +67762,9 @@ aPf
 aPf
 aWo
 awV
-aFP
-amT
-aFP
+aAd
+pUQ
+aAd
 veh
 gtO
 aIr
@@ -67857,7 +67782,7 @@ eNI
 jtc
 qnH
 vdW
-axC
+vdW
 nWn
 kJq
 jgG
@@ -68094,9 +68019,9 @@ aPf
 aPf
 ayI
 ajj
-aFP
-aFP
-aFP
+aAd
+aAd
+aAd
 agU
 gtO
 auH
@@ -68112,9 +68037,9 @@ aIr
 tvh
 nlv
 jtc
-yde
+bHC
 erR
-owC
+oVT
 nWn
 hOy
 ekp
@@ -68353,7 +68278,7 @@ ayI
 ajj
 ajj
 kMV
-aFP
+aAd
 agU
 hpl
 rXY
@@ -68369,9 +68294,9 @@ aGR
 tvh
 ifZ
 jtc
-bHC
+roh
 fOu
-axC
+roh
 nWn
 qHT
 vTT
@@ -68609,8 +68534,8 @@ ayI
 ayI
 ayI
 ajj
-aFP
-aFP
+aAd
+aAd
 agU
 gtO
 aCs
@@ -68626,8 +68551,8 @@ aIr
 tvh
 ayt
 jtc
-jdx
-yde
+vdW
+xbn
 jdx
 nWn
 xuk
@@ -68866,7 +68791,7 @@ ayI
 ayI
 ayI
 ajj
-aFP
+aAd
 aeT
 agU
 gtO
@@ -68884,7 +68809,7 @@ tvh
 eNI
 jtc
 xbn
-itm
+roh
 rvn
 nWn
 xDp
@@ -69123,8 +69048,8 @@ ayI
 ayI
 ayI
 ajj
-aFP
-aFP
+aAd
+aAd
 agU
 gtO
 wfN
@@ -69140,9 +69065,9 @@ aIr
 tvh
 sUE
 jtc
-fOu
-vdW
-yde
+aWy
+roh
+bHC
 nWn
 hOy
 vTT
@@ -69381,7 +69306,7 @@ ayI
 ajj
 ajj
 aeT
-aFP
+aAd
 agU
 gtO
 aIr
@@ -69397,9 +69322,9 @@ aIr
 tvh
 sUE
 alW
-owC
+oVT
 alo
-qnH
+aAc
 nWn
 apT
 vTT
@@ -69636,8 +69561,8 @@ aPf
 ayI
 aWo
 ajj
-aFP
-aFP
+aAd
+aAd
 asX
 agU
 nXw
@@ -69654,9 +69579,9 @@ aIr
 dzn
 sUE
 alW
-yde
 bHC
 roh
+bHC
 nWn
 apT
 vTT
@@ -69893,9 +69818,9 @@ aPf
 ayI
 aWo
 awV
-aFP
+aAd
 asX
-aFP
+aAd
 agU
 nXw
 aSt
@@ -69911,9 +69836,9 @@ aQE
 jEk
 gRb
 alW
-qnH
-pux
-roh
+aAc
+bHC
+bHC
 nWn
 rkW
 vTT
@@ -70151,8 +70076,8 @@ ayI
 aPf
 ajj
 ajj
-aFP
-aFP
+aAd
+aAd
 agU
 qze
 kKs
@@ -70409,7 +70334,7 @@ aPf
 aPf
 ajj
 ajj
-aFP
+aAd
 agU
 ayI
 ayI

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -260,10 +260,6 @@
 /obj/structure/flora/grass/green/style_2,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
-"agF" = (
-/obj/structure/flora/bush/grassy/style_4,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "agG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -310,13 +306,12 @@
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafepark)
 "ahs" = (
-/obj/structure/flora/bush/leavy/style_2,
+/obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahA" = (
 /obj/structure/flora/bush/flowers_br,
 /obj/structure/flora/bush/fullgrass,
-/obj/structure/flora/bush/pointy,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahG" = (
@@ -363,8 +358,10 @@
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "ahU" = (
-/obj/structure/flora/bush/large,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/centcom/holding/cafepark)
 "ahY" = (
 /obj/structure/chair/sofa/corp/right{
@@ -475,7 +472,7 @@
 /obj/structure/flora/rock/pile{
 	icon_state = "basalt3"
 	},
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafe)
 "aka" = (
 /obj/effect/turf_decal/box,
@@ -617,7 +614,7 @@
 /area/centcom/holding/cafepark)
 "alH" = (
 /obj/structure/fans/tiny/invisible,
-/turf/open/misc/grass/planet,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafe)
 "alM" = (
 /obj/item/reagent_containers/cup/glass/shaker{
@@ -834,11 +831,10 @@
 	},
 /area/centcom/holding/cafepark)
 "anC" = (
-/obj/structure/flora/rock/pile/jungle/large{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
 	},
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/turf/open/floor/wood,
 /area/centcom/holding/cafepark)
 "anL" = (
 /obj/structure/table/wood,
@@ -1574,7 +1570,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "axw" = (
-/obj/structure/flora/bush/leavy/style_3,
+/obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "axz" = (
@@ -1792,8 +1788,14 @@
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
 "azk" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "azl" = (
 /obj/effect/turf_decal/tile/green{
@@ -1948,8 +1950,12 @@
 /turf/closed/indestructible/steel,
 /area/centcom/holding/cafe)
 "aAz" = (
-/obj/structure/flora/bush/jungle/a/style_3,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/structure/spacevine{
+	name = "thick vines";
+	opacity = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aAC" = (
 /obj/structure/fluff/tram_rail/end{
@@ -2086,7 +2092,6 @@
 "aBr" = (
 /obj/structure/flora/bush/fullgrass,
 /obj/structure/flora/bush/flowers_yw,
-/obj/structure/flora/bush/sunny,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aBs" = (
@@ -2393,13 +2398,7 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aFB" = (
-/obj/structure/flora/bush/ferny,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
-"aFI" = (
-/obj/structure/flora/tree/jungle/small{
-	icon_state = "tree6"
-	},
+/obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aFK" = (
@@ -2427,10 +2426,6 @@
 /area/centcom/holding/cafepark)
 "aGb" = (
 /turf/closed/indestructible/riveted/boss,
-/area/centcom/holding/cafepark)
-"aGg" = (
-/obj/structure/flora/bush/large/style_2,
-/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aGk" = (
 /obj/machinery/bookbinder,
@@ -2793,8 +2788,11 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
 "aKu" = (
-/obj/structure/flora/bush/jungle/b,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/structure/railing/wooden_fencing,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/centcom/holding/cafepark)
 "aKA" = (
 /obj/structure/chair/sofa/corp/right,
@@ -2915,10 +2913,6 @@
 /obj/structure/flora/bush/snow/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
-"aMJ" = (
-/obj/structure/flora/tree/jungle,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "aMM" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -3013,12 +3007,6 @@
 	icon_state = "darkfull"
 	},
 /area/centcom/holding/cafe)
-"aNk" = (
-/obj/structure/flora/bush/large{
-	icon_state = "bush3"
-	},
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "aNp" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block{
@@ -3052,9 +3040,11 @@
 	},
 /area/centcom/holding/cafe)
 "aNB" = (
-/obj/structure/flora/bush/leavy/style_3,
-/obj/structure/flora/tree/jungle,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/structure/spacevine,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "aNF" = (
 /obj/structure/fans/tiny/invisible,
@@ -3325,11 +3315,6 @@
 "aQf" = (
 /turf/open/water/beach,
 /area/centcom/holding/cafepark)
-"aQw" = (
-/obj/structure/flora/grass/jungle/b/style_random,
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "aQx" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
@@ -3533,16 +3518,6 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
-"aRP" = (
-/obj/structure/flora/bush/sparsegrass,
-/obj/structure/flora/biolumi/flower{
-	light_color = "#D9FF00";
-	light_power = 0.3;
-	light_range = 10;
-	random_light = null
-	},
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "aRS" = (
 /turf/open/misc/beach/coast/corner{
 	dir = 4
@@ -3602,12 +3577,6 @@
 /area/centcom/holding/cafe)
 "aSq" = (
 /turf/open/misc/beach/coast/corner,
-/area/centcom/holding/cafepark)
-"aSs" = (
-/obj/structure/flora/tree/jungle/small{
-	icon_state = "tree4"
-	},
-/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aSt" = (
 /obj/effect/turf_decal/sand,
@@ -3680,10 +3649,6 @@
 	dir = 4
 	},
 /turf/open/indestructible/plating,
-/area/centcom/holding/cafepark)
-"aTu" = (
-/obj/structure/flora/bush/grassy/style_2,
-/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aTv" = (
 /obj/structure/closet/crate/bin,
@@ -3881,10 +3846,6 @@
 	dir = 9
 	},
 /area/centcom/holding/cafepark)
-"aVA" = (
-/obj/structure/flora/bush/generic,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "aVC" = (
 /obj/machinery/shower/directional/west,
 /turf/open/indestructible/bathroom,
@@ -3922,10 +3883,6 @@
 /area/centcom/holding/cafe)
 "aWi" = (
 /turf/open/floor/holofloor/beach/water,
-/area/centcom/holding/cafepark)
-"aWj" = (
-/obj/structure/flora/bush/grassy/style_3,
-/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/holding/cafepark)
 "aWo" = (
 /obj/structure/spacevine{
@@ -7915,10 +7872,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
-"hBy" = (
-/obj/structure/flora/tree/jungle/style_random,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "hEK" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -9514,11 +9467,6 @@
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble,
 /area/centcom/holding/cafepark)
-"kuV" = (
-/obj/structure/flora/bush/leavy/style_2,
-/obj/structure/flora/tree/jungle/style_random,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "kvD" = (
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/dark,
@@ -9842,10 +9790,6 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
-"kWr" = (
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
 "kWA" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
@@ -17700,8 +17644,11 @@
 /turf/open/misc/beach/sand,
 /area/centcom/holding/cafepark)
 "xFZ" = (
-/obj/structure/flora/bush/sunny,
-/turf/open/misc/asteroid/snow/indestructible/planet,
+/obj/structure/railing/wooden_fencing,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/centcom/holding/cafepark)
 "xGO" = (
 /obj/structure/railing{
@@ -54666,13 +54613,13 @@ ajj
 ajj
 ajj
 ajj
+ahs
+pAF
 aAd
 aAd
 aAd
 aAd
-axw
-kgI
-aAz
+aAd
 aMW
 vyS
 ajj
@@ -54681,7 +54628,7 @@ ajj
 ajj
 ajj
 kgI
-ahs
+aAd
 ajj
 ajj
 ajj
@@ -54921,20 +54868,20 @@ aAd
 aAd
 aAd
 asF
-aMJ
+aAd
 kPK
+bkt
 aAd
 aAd
-aAd
-aAd
+izJ
 aAd
 aLH
+amk
 aAd
-aMJ
 aBr
 aAd
 aAd
-aMJ
+aAd
 aAd
 aAd
 akp
@@ -55178,30 +55125,30 @@ aAd
 avb
 aLH
 aAd
-aAd
+pgl
 kPK
 aAd
+sLB
+izJ
 aAd
-aAd
-aAd
-aVA
+amk
 aAd
 aCM
 aeT
 aAd
 aAd
-aAd
+amk
 aCM
 aAd
 aAd
 aAd
 aLH
 aAd
-hBy
 aAd
 aAd
 aAd
-aMJ
+aAd
+kgI
 ajj
 ajj
 bFi
@@ -55429,7 +55376,7 @@ ajj
 ajj
 aCM
 kgI
-ahU
+aAd
 aAd
 aIV
 ahA
@@ -55440,26 +55387,26 @@ kPK
 aAd
 kgI
 aAd
+izJ
 aAd
-aFB
 akp
-azk
-aAd
-kWr
-aFB
 aAd
 aAd
-aVA
+kgI
+aAd
+aAd
+aAd
+aAd
 aIV
-aNB
-aAd
-aKu
 aAd
 aAd
 aAd
 aAd
+amk
 aAd
-anC
+aAd
+aAd
+aAd
 ajj
 aCv
 twL
@@ -55687,26 +55634,26 @@ ajK
 ahQ
 aLH
 aAd
-axw
+pgl
 aAd
-aAz
-ahs
+aAd
+aAd
 aAd
 ybS
 kPK
 aAd
 aAd
-aAd
-aAd
-aAd
-vyS
-aMJ
+amk
 aAd
 aAd
 aAd
 aAd
 aAd
 aAd
+aAd
+aAd
+aAd
+amk
 aAd
 aAd
 aBr
@@ -55714,8 +55661,8 @@ aCM
 aFV
 aAd
 aAd
-aAd
-aAd
+izJ
+izJ
 aAd
 ajj
 aUm
@@ -55941,37 +55888,37 @@ aWo
 ajj
 ajj
 aAd
-aAz
 aAd
-axw
 aAd
-aFB
+aAd
+aAd
+aAd
 aAd
 kgI
 ahQ
 aAd
 kPK
+izJ
 aAd
 aAd
 aAd
 aAd
-ahU
 aAd
 ayd
 aBp
-kWr
+aAd
 aAd
 rMZ
 aAd
-kWr
-kWr
 aAd
-arT
+aAd
+aAd
+aAd
 ayd
-vyS
 aAd
-aNk
 aAd
+aAd
+amk
 aAd
 avb
 ajj
@@ -56208,10 +56155,10 @@ aAd
 aAd
 ayd
 kPK
-aKu
+aAd
+izJ
 aAd
 aAd
-vyS
 asX
 aLH
 aAd
@@ -56221,7 +56168,7 @@ hWY
 aFP
 goK
 aAd
-aAd
+izJ
 aAd
 aAd
 aAd
@@ -56467,11 +56414,11 @@ aAd
 aCQ
 aAd
 aAd
-ahs
+aAd
 aeT
 ybS
 aAd
-kuV
+aAd
 aAd
 uwP
 aAd
@@ -56479,16 +56426,16 @@ aPC
 aAd
 aAd
 aAd
+izJ
 aAd
-aMJ
 aAd
 aAd
 aLH
 ybS
 aAd
-kgI
-ayI
-ayI
+aAd
+lgt
+aiD
 aqf
 aBT
 aUu
@@ -56717,34 +56664,34 @@ ihd
 ihd
 aqf
 aAd
-axw
+aAd
+pgl
 aAd
 aAd
-ahU
 kPK
 aIV
 aAd
 aAd
 aAd
-vyS
-aFB
+aAd
+amk
 aAd
 aBr
 aAd
-kWr
+aAd
 lZn
 lZn
 aAd
 aAd
 aAd
-vyS
+aAd
 aeT
 ahs
 aMW
 aAd
 aAd
 aAd
-ayI
+aCX
 ayI
 dWE
 amF
@@ -56974,17 +56921,17 @@ ihd
 lLN
 aqf
 aAd
+gyS
 aAd
-aAd
-aAd
+aLH
 aAd
 kPK
 aAd
 aAd
+amk
 aAd
-azk
-aRP
-aNk
+ahQ
+aAd
 arT
 aLH
 aAd
@@ -56992,17 +56939,17 @@ aAd
 aAd
 aAd
 aAd
-aQw
-kWr
+amk
+aAd
 aAd
 alf
 aAd
-aVA
 aAd
-vyS
 aAd
-ayI
-ayI
+aAd
+izJ
+aCX
+pib
 aqf
 paJ
 amF
@@ -57231,10 +57178,10 @@ weP
 aqf
 aqf
 aAd
+aLH
 aAd
 aAd
 aAd
-xFZ
 kPK
 aAd
 akp
@@ -57246,7 +57193,7 @@ avb
 aAd
 ahQ
 aIE
-aNk
+aAd
 asX
 aAd
 aAd
@@ -57258,7 +57205,7 @@ aAd
 akp
 aAd
 aAd
-ayI
+aoE
 aAd
 aqf
 aqf
@@ -57487,8 +57434,8 @@ cmh
 gOS
 smx
 aqf
-aAd
-aAd
+gTx
+ovF
 aAd
 aAd
 kgI
@@ -57498,25 +57445,25 @@ aAd
 aAd
 aLH
 aAd
-aMJ
 aAd
 aAd
 aAd
-aMJ
-aAd
-aVA
-aAd
-aAd
-azk
-aAz
+amk
 aAd
 aAd
 aAd
-aMJ
+aAd
+kgI
 aAd
 aAd
-ayI
 aAd
+amk
+aAd
+aAd
+izJ
+aAd
+aoE
+alF
 aqf
 aRx
 aqf
@@ -57744,9 +57691,9 @@ qXC
 bAr
 agk
 kJU
+aFB
 aAd
-aAd
-axw
+ybS
 aAd
 aAd
 bja
@@ -57755,7 +57702,7 @@ aAd
 alF
 aAd
 aAd
-aAd
+amk
 aAd
 aAd
 asF
@@ -57770,9 +57717,9 @@ aAd
 aAd
 asF
 aAd
+amk
 aAd
-aAd
-ayI
+aoE
 aAd
 aqf
 qWc
@@ -58001,17 +57948,17 @@ qXC
 orU
 vYI
 kJU
-aHl
-aHl
-aHl
-aHl
-nJO
+ahU
+ahU
+ahU
+ahU
+aKu
 aLu
-ayI
-ayI
+aiD
+aDB
 aIV
 ahQ
-aFB
+aAd
 aAd
 aAd
 aAd
@@ -58020,16 +57967,16 @@ aAd
 aAd
 aAd
 aAd
-aMJ
-agF
+amk
+aAd
 atQ
 aAd
 aFV
 aAd
 afA
-ahU
 aAd
-ayI
+aAd
+aoE
 aAd
 aqf
 aqf
@@ -58266,15 +58213,15 @@ aHl
 aLu
 ayI
 ayI
-ayI
+aDB
 atQ
 aAd
 aLH
 aAd
-aWj
-kgI
 aAd
 aAd
+aAd
+izJ
 aAd
 aAd
 aAd
@@ -58284,9 +58231,9 @@ alF
 aAd
 aAd
 aLH
-ahs
 aAd
-ayI
+izJ
+aoE
 aAd
 kgI
 aqf
@@ -58515,37 +58462,37 @@ vNs
 bIO
 acF
 kJU
-aHl
-aHl
-aHl
-aHl
-nJO
+anC
+anC
+anC
+anC
+xFZ
 aLu
+pib
+pib
 ayI
-ayI
-ayI
-ayI
+aDB
 aAd
 aAd
 aAd
 aAd
-azk
 aAd
 aAd
+amk
 aAd
-aAz
+aAd
 asF
 aAd
 aAd
 aAd
-azk
-vyS
 aAd
 aAd
 aAd
-ayI
-ayI
-ayI
+aAd
+aAd
+aCX
+tMb
+tMb
 cOu
 aUo
 eeZ
@@ -58778,29 +58725,29 @@ aAd
 ybS
 kgI
 mCg
+ahQ
 aAd
-aAd
+aSZ
 ayI
-ayI
-ayI
-ayI
-ayI
+aiD
+aiD
+aDB
 aAd
 aLH
 aAd
-aTu
+aAd
 aBr
 aAd
 aAd
 aLH
-kgI
 aAd
+amk
 aAd
 aIV
 aAd
-aVA
+aAd
 ybS
-ayI
+aoE
 aAd
 aAd
 aqf
@@ -59035,14 +58982,14 @@ aAd
 aAd
 aAd
 kPK
+amk
+ahQ
 aAd
-aAd
-aAd
+aCX
 ayI
+pib
 ayI
-ayI
-ayI
-ayI
+aDB
 aAd
 aAd
 aAd
@@ -59050,16 +58997,16 @@ aAd
 aIE
 aAd
 aAd
-axw
-aCM
-aGg
 aAd
-aAz
+aCM
+aAd
+aAd
+aAd
 asX
 aAd
-ayI
+aoE
 ayd
-aMJ
+amk
 aqf
 aqf
 aqf
@@ -59289,7 +59236,7 @@ aqf
 aAd
 aAd
 aAd
-aSs
+pgl
 aAd
 lwv
 lwv
@@ -59298,8 +59245,8 @@ lwv
 lwv
 lwv
 aAd
-ayI
-ayI
+aCX
+nzn
 aAd
 aAd
 aAd
@@ -59309,25 +59256,25 @@ aAd
 aAd
 aAd
 aAd
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
+lgt
+aiD
+aiD
+aiD
+aiD
+nzn
 aAd
 aAd
+izJ
+iqT
+izJ
 aAd
-axw
-aAd
-axw
 aAd
 aAd
 atp
 atp
 atp
-aTR
-cBT
+azk
+aNB
 atp
 aPf
 aPf
@@ -59544,7 +59491,7 @@ jgt
 aSP
 aSP
 aAd
-azk
+pgl
 aAd
 aAd
 aAd
@@ -59569,16 +59516,16 @@ smT
 gmT
 gmT
 aVI
+pib
+pib
 ayI
-ayI
-ayI
-ayI
+aDB
 aAd
 aAd
+izJ
 aAd
 aAd
-aAd
-kWr
+izJ
 aAd
 aAd
 ajj
@@ -59828,22 +59775,22 @@ akW
 sDY
 aAd
 aAd
+aSZ
 ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
+aiD
+aiD
+aiD
+aiD
+aDB
+kgI
 aAd
 aAd
 aAd
-aFI
+aAd
+aAd
+aAd
 axw
-aAd
-aAd
-axw
-aAd
+izJ
 aAd
 aPf
 aPf
@@ -60083,29 +60030,29 @@ fFr
 qNu
 fFr
 wBV
-kWr
+gyS
+aAd
+aIE
+aSZ
+pib
+pib
+pib
+pib
+ayI
+aDB
 aAd
 aAd
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
+mon
+axw
+izJ
 aAd
 aAd
 aAd
 aAd
 aAd
+izJ
 aAd
-aAd
-vyS
-aAd
-ayI
-ayI
-ayI
-ayI
+aCX
 aYQ
 azB
 azB
@@ -60341,28 +60288,28 @@ hfJ
 gqq
 wBV
 aAd
-kWr
-kWr
-aAd
-aAd
-aAd
-kgI
-aAd
-ayI
-ayI
-aAd
-kgI
+gyS
 aAd
 aAd
 aAd
 aAd
-kgI
 aAd
-ayI
-ayI
-ayI
-ayI
-ayI
+izJ
+aCX
+nzn
+ovF
+aAd
+aAd
+aAd
+aAd
+aAd
+izJ
+aAd
+lgt
+aiD
+aiD
+ppd
+pib
 asw
 aOG
 azB
@@ -60604,22 +60551,22 @@ aqf
 aTb
 aqf
 aqf
-kWr
-ayI
-ayI
+kgI
+aCX
+nzn
+gTx
+aAd
+izJ
 aAd
 aAd
+amk
 aAd
 aAd
-aAd
-aMJ
-aAd
-aAd
-ayI
-ayI
+aCX
+pib
 aPf
-ayI
-ayI
+axw
+izJ
 asw
 aOG
 azB
@@ -60862,17 +60809,17 @@ aUo
 aBk
 aqf
 aAd
-ayI
-ayI
+aCX
+nzn
+aAd
+izJ
 aAd
 aAd
 aAd
 aAd
 aAd
-aAd
-aAd
-ayI
-ayI
+lgt
+eNw
 aAd
 aPf
 aPf
@@ -61118,19 +61065,19 @@ aWT
 aUo
 aqO
 aqf
-aAd
+izJ
+aCX
 ayI
-ayI
-ayI
+aDB
 aAd
 aAd
 aAd
 aAd
-aAd
-ayI
-ayI
-aAd
-aAd
+kgI
+lgt
+nzn
+kgI
+izJ
 aPf
 aPf
 ajj
@@ -61375,18 +61322,18 @@ aUo
 aUo
 aUo
 aUK
+aiD
 ayI
 ayI
 ayI
+aiD
+aiD
+aiD
+aiD
+aiD
 ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-aAd
+nzn
+izJ
 aAd
 aPf
 aPf
@@ -61634,12 +61581,12 @@ afF
 aqf
 ayI
 ayI
-ayI
-ayI
-ayI
-ayI
-ayI
-ayI
+pib
+pib
+pib
+pib
+pib
+pib
 ayI
 aPf
 aPf
@@ -61890,14 +61837,14 @@ aUo
 aGk
 aqf
 ayI
-ayI
+nzn
+gyS
 aAd
 aAd
-aMJ
+pgl
+izJ
 aAd
-aAd
-aAd
-ayI
+aSZ
 aWo
 ayI
 aPf
@@ -62147,18 +62094,18 @@ dau
 aqf
 aqf
 ayI
-ayI
+nzn
 aAd
-kgI
-kWr
+izJ
 aAd
-kWr
 aAd
+aAd
+izJ
 aAd
 aPf
 ayI
 aPf
-kgI
+aAd
 aAd
 aLH
 ajj
@@ -62402,10 +62349,10 @@ nps
 vxF
 pej
 aqf
-kWr
-ayI
-ayI
-aAd
+mon
+aCX
+nzn
+izJ
 aAd
 aqf
 aqf
@@ -62416,7 +62363,7 @@ aqf
 ejQ
 aqf
 aqf
-aVA
+aAd
 aAd
 ajj
 aaa
@@ -62659,10 +62606,10 @@ bcb
 bcb
 pej
 aqf
+aiD
 ayI
-ayI
-ayI
-kWr
+nzn
+aAd
 vUv
 aqf
 aUo
@@ -62673,7 +62620,7 @@ jQJ
 aUo
 sHR
 aqf
-ahU
+aAd
 akp
 ajj
 aaa
@@ -62916,9 +62863,9 @@ bcb
 bcb
 pej
 aqf
+pib
 ayI
-ayI
-ayI
+nzn
 aAd
 xFE
 aqf
@@ -63174,8 +63121,8 @@ bcb
 ujV
 aqf
 kgI
-ayI
-ayI
+aSZ
+nzn
 aAd
 aAd
 aqf
@@ -63431,10 +63378,10 @@ aqf
 aqf
 aqf
 aqf
-kWr
-ayI
 aAd
-kWr
+aoE
+aAd
+pgl
 aqf
 nii
 aUo
@@ -63688,10 +63635,10 @@ paj
 fPs
 amF
 aqf
+izJ
+aoE
 aAd
-ayI
-aAd
-aAd
+izJ
 aqf
 sFB
 aUo
@@ -63946,9 +63893,9 @@ amF
 amF
 aqf
 aAd
-ayI
+aoE
 aAd
-kgI
+aAd
 aqf
 aZW
 aUo
@@ -63959,7 +63906,7 @@ aUo
 aUz
 aqf
 npr
-aFB
+aAd
 ajj
 aaa
 aaa
@@ -64203,9 +64150,9 @@ amF
 amF
 ahP
 aAd
-ayI
-ayI
-aAd
+aCX
+aDB
+izJ
 aqf
 aYO
 aUo
@@ -64216,7 +64163,7 @@ aUo
 aUo
 pcp
 jbu
-vyS
+aAd
 ajj
 aaa
 aaa
@@ -64459,9 +64406,9 @@ amF
 amF
 amF
 aqf
-kWr
-ayI
-ayI
+kgI
+aCX
+nzn
 aAd
 aqf
 aqf
@@ -65244,7 +65191,7 @@ aqf
 srA
 caY
 akp
-aNk
+aAd
 ajj
 ajj
 ajj
@@ -67760,7 +67707,7 @@ aaa
 ajj
 aPf
 aPf
-aWo
+aAz
 awV
 aAd
 pUQ
@@ -68021,7 +67968,7 @@ ayI
 ajj
 aAd
 aAd
-aAd
+pgl
 agU
 gtO
 auH
@@ -68791,7 +68738,7 @@ ayI
 ayI
 ayI
 ajj
-aAd
+mon
 aeT
 agU
 gtO
@@ -69816,7 +69763,7 @@ aaa
 ajj
 aPf
 ayI
-aWo
+aAz
 awV
 aAd
 asX
@@ -70077,7 +70024,7 @@ aPf
 ajj
 ajj
 aAd
-aAd
+mon
 agU
 qze
 kKs

--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -1428,12 +1428,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding/cafe)
 "avt" = (
-/obj/structure/flora/tree/pine/style_3{
-	step_x = 15;
-	step_y = -7
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/misc/asteroid/snow/indestructible/planet,
-/area/centcom/holding/cafepark)
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "avu" = (
 /obj/vehicle/ridden/janicart/upgraded,
 /obj/item/key/janitor,
@@ -2776,7 +2775,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "aKc" = (
 /turf/open/indestructible/cobble/side,
@@ -4315,7 +4314,7 @@
 	dir = 4
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "bkt" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -4386,7 +4385,7 @@
 "bnU" = (
 /obj/structure/flora/tree/stump,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "boa" = (
 /obj/machinery/button/door{
@@ -4894,7 +4893,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "bWy" = (
 /obj/machinery/button/door/indestructible/no_telekinesis/directional/east{
@@ -4989,13 +4988,19 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"cds" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "cfs" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/remains/xeno/larva,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
 "cfu" = (
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "cgU" = (
 /obj/effect/light_emitter/interlink,
@@ -5008,7 +5013,7 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "chT" = (
 /obj/structure/table/wood,
@@ -5066,7 +5071,7 @@
 	dir = 5
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "cna" = (
 /obj/structure/chair/wood{
@@ -5300,7 +5305,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "cIk" = (
 /obj/effect/turf_decal/siding/white{
@@ -5365,7 +5370,7 @@
 "cNw" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "cOu" = (
 /obj/machinery/door/airlock/wood{
@@ -5394,7 +5399,7 @@
 /obj/structure/hedge,
 /obj/effect/light_emitter/interlink,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "cQH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5532,7 +5537,7 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dcP" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
@@ -5567,7 +5572,7 @@
 	dir = 1
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dgl" = (
 /obj/effect/spawner/liquids_spawner,
@@ -5596,9 +5601,11 @@
 /turf/open/floor/wood/large,
 /area/centcom/holding/cafe)
 "dky" = (
-/obj/structure/flora/tree/jungle/style_4,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "dkD" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -5626,7 +5633,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dmb" = (
 /obj/machinery/light/cold/directional/south,
@@ -5652,7 +5659,7 @@
 "dsH" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dsW" = (
 /obj/item/storage/basket,
@@ -5683,7 +5690,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dyE" = (
 /obj/machinery/light/directional/west,
@@ -5943,7 +5950,7 @@
 "dVb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "dVh" = (
 /obj/machinery/door/airlock{
@@ -6298,6 +6305,16 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"eJZ" = (
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/interlink)
 "eKr" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -6394,12 +6411,12 @@
 /area/centcom/interlink)
 "eRB" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "eSk" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "eSC" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -6770,7 +6787,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fFL" = (
 /obj/machinery/light/directional/south,
@@ -6804,7 +6821,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fHA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -6814,25 +6831,25 @@
 "fHV" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fIS" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fIY" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fJQ" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fLD" = (
 /obj/effect/turf_decal/siding/wood{
@@ -6898,7 +6915,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fPs" = (
 /obj/item/kirbyplants/random,
@@ -6992,7 +7009,7 @@
 "fVr" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "fWc" = (
 /obj/structure/chair/sofa/bench/left{
@@ -7239,6 +7256,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
 	},
 /turf/open/indestructible/plating,
@@ -7501,7 +7521,7 @@
 /obj/structure/statue/sandstone/venus{
 	name = "Order"
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "gZK" = (
 /obj/structure/table/wood,
@@ -7554,7 +7574,7 @@
 	dir = 4
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "hbY" = (
 /obj/structure/stone_tile/block,
@@ -7607,8 +7627,8 @@
 	dir = 1
 	},
 /obj/effect/light_emitter/interlink,
-/obj/structure/flora/tree/jungle/small/style_5,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "hfJ" = (
 /obj/structure/fans/tiny/invisible,
@@ -7739,6 +7759,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafepark)
 "hpP" = (
@@ -7749,7 +7772,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "hpX" = (
 /obj/effect/turf_decal/tile/blue,
@@ -8154,7 +8177,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "iet" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -8299,9 +8322,9 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "iov" = (
-/obj/structure/flora/tree/jungle/small/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/pine/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "ioz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -8510,7 +8533,7 @@
 	dir = 5
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "iGO" = (
 /obj/structure/bookcase/random/religion,
@@ -8611,7 +8634,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/hedge,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "iTf" = (
 /obj/structure/chair/sofa/bench{
@@ -8673,10 +8696,20 @@
 /turf/open/floor/iron/freezer,
 /area/centcom/interlink)
 "iXq" = (
-/obj/structure/flora/tree/jungle,
-/obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
-/area/centcom/interlink)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafepark)
 "iXZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8823,7 +8856,7 @@
 "jgT" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence/corner,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "jhu" = (
 /obj/machinery/duct,
@@ -8958,7 +8991,7 @@
 	dir = 10
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "jtl" = (
 /obj/structure/chair/sofa/bench/left{
@@ -9200,7 +9233,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "jTQ" = (
 /obj/effect/turf_decal/delivery,
@@ -9310,7 +9343,7 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "kdy" = (
 /obj/structure/sink/directional/south,
@@ -9399,8 +9432,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "knx" = (
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/dead/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "knL" = (
 /obj/structure/chair/sofa/right/brown,
@@ -9460,7 +9493,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "kso" = (
 /obj/machinery/light/directional/south,
@@ -9682,7 +9715,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "kMe" = (
 /turf/open/misc/beach/sand{
@@ -9832,7 +9865,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "kZK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -10404,10 +10437,18 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "lTP" = (
-/obj/effect/light_emitter/interlink,
-/obj/structure/flora/tree/jungle/style_6,
-/turf/open/floor/grass,
-/area/centcom/interlink)
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/indestructible/plating,
+/area/centcom/holding/cafepark)
 "lVs" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -10587,7 +10628,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "moe" = (
 /obj/structure/closet,
@@ -10866,7 +10907,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "mDS" = (
 /obj/machinery/hypnochair,
@@ -10931,7 +10972,7 @@
 	dir = 9
 	},
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "mLK" = (
 /obj/structure/table/wood,
@@ -11433,7 +11474,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "nJp" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line,
@@ -11468,7 +11509,7 @@
 	dir = 8
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "nLr" = (
 /obj/structure/fake_stairs/wood/directional/east,
@@ -11556,7 +11597,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "nQF" = (
 /obj/effect/turf_decal/siding/wood{
@@ -11915,7 +11956,7 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "oyf" = (
 /obj/structure/flora/bush/sunny{
@@ -11980,7 +12021,7 @@
 	dir = 4
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "ozJ" = (
 /obj/structure/railing/wooden_fencing,
@@ -12054,8 +12095,8 @@
 	},
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/dead/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "oDs" = (
 /obj/effect/turf_decal/siding/white{
@@ -12371,7 +12412,7 @@
 	dir = 8
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "pci" = (
 /obj/structure/mineral_door/wood/large_gate{
@@ -12521,7 +12562,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "pmJ" = (
 /obj/machinery/light/directional/west,
@@ -12546,7 +12587,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "ppd" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -12735,6 +12776,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"pEO" = (
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/centcom/interlink)
 "pET" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -12770,14 +12818,14 @@
 /area/centcom/interlink)
 "pFt" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "pFM" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence/interlink{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "pGK" = (
 /turf/open/floor/iron/dark/side,
@@ -12970,8 +13018,10 @@
 /area/centcom/interlink)
 "pPO" = (
 /obj/effect/light_emitter/interlink,
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/centcom/interlink)
 "pQp" = (
 /obj/structure/bed/pod{
@@ -13095,7 +13145,7 @@
 	dir = 6
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "pZh" = (
 /obj/structure/chair/sofa/bench{
@@ -13315,7 +13365,7 @@
 	dir = 9
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "qoB" = (
 /obj/structure/toilet/snappop{
@@ -13399,7 +13449,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "qvk" = (
 /obj/machinery/oven/range,
@@ -13437,6 +13487,9 @@
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
 	},
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafepark)
@@ -13646,7 +13699,7 @@
 	dir = 1;
 	name = "Law"
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "qTa" = (
 /obj/structure/chair/sofa/bench/left{
@@ -13735,7 +13788,7 @@
 "qWZ" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fluff/arc,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "qXC" = (
 /turf/open/floor/bamboo,
@@ -13746,7 +13799,7 @@
 /obj/structure/fence/interlink{
 	dir = 4
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "rbo" = (
 /obj/structure/table,
@@ -13885,19 +13938,17 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "rne" = (
-/obj/item/paper{
-	default_raw_text = "Hello valued Patron! The Cafe has underwent recent renovations! The most noticable additions are a horror themed 'Hive' room in the southeast (please note that due to this theme, there are currently no doors, managment is looking into adding them) and a Sci-Fi 'Alien abduction' theme, just south of the Drobe room. Thank you,\n -The Managment.";
-	name = "notice to visitors"
+/obj/effect/light_emitter/interlink,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
 	},
-/turf/open/indestructible/hoteltile{
-	icon_state = "darkfull"
-	},
-/area/centcom/holding/cafe)
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/interlink)
 "rng" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "rnK" = (
 /obj/effect/turf_decal/tile/blue{
@@ -14001,7 +14052,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "rDL" = (
 /obj/effect/turf_decal/siding/white{
@@ -14261,7 +14312,7 @@
 "rSa" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "rSu" = (
 /obj/machinery/door/airlock/medical{
@@ -14330,7 +14381,7 @@
 "rVQ" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "rXY" = (
 /obj/effect/light_emitter/interlink,
@@ -14451,7 +14502,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "shn" = (
 /obj/structure/railing/corner,
@@ -14667,7 +14718,7 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "svm" = (
 /obj/machinery/door/airlock{
@@ -14694,8 +14745,8 @@
 /area/centcom/interlink)
 "syc" = (
 /obj/effect/light_emitter/interlink,
-/obj/structure/flora/bush/large/style_random,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/dead/style_random,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "sys" = (
 /obj/machinery/shower/directional/west,
@@ -14807,7 +14858,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "sHR" = (
 /obj/structure/musician/piano,
@@ -15078,8 +15129,8 @@
 /area/centcom/holding/cafe)
 "sZl" = (
 /obj/effect/light_emitter/interlink,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "sZM" = (
 /obj/structure/dresser{
@@ -15145,7 +15196,7 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "tdP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15328,7 +15379,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "twL" = (
 /turf/open/misc/beach/coast{
@@ -15450,7 +15501,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "tKt" = (
 /turf/open/floor/plating/abductor,
@@ -15492,12 +15543,12 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "tUk" = (
 /obj/structure/fence/corner,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "tUz" = (
 /obj/structure/chair/sofa/bench/right{
@@ -15619,7 +15670,7 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "uaY" = (
 /obj/structure/wall_torch/spawns_lit/directional/south,
@@ -15767,6 +15818,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/interlink)
+"uhT" = (
+/obj/effect/light_emitter/interlink,
+/obj/effect/spawner/random/structure/billboard/nanotrasen,
+/turf/open/misc/asteroid/snow/indestructible/planet,
+/area/centcom/interlink)
 "uis" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/iron/dark,
@@ -15895,7 +15951,7 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "uwP" = (
 /obj/structure/chair/wood,
@@ -16049,8 +16105,8 @@
 "uKH" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
-/obj/structure/flora/tree/jungle/small/style_6,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "uKW" = (
 /obj/structure/chair/sofa/bench,
@@ -16197,7 +16253,7 @@
 /area/centcom/holding/cafe)
 "vat" = (
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "vaB" = (
 /obj/machinery/door/airlock/hatch{
@@ -16336,7 +16392,7 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "vsB" = (
 /obj/structure/chair/sofa/bench/left,
@@ -16803,7 +16859,7 @@
 	dir = 1
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "wji" = (
 /obj/structure/flora/rock/style_random,
@@ -16875,7 +16931,7 @@
 "wpz" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "wqC" = (
 /obj/structure/lavaland/ash_walker_fake,
@@ -16886,8 +16942,8 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
+/obj/structure/flora/tree/pine/style_2,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "wrf" = (
 /turf/open/floor/carpet/blue,
@@ -16941,7 +16997,7 @@
 	dir = 4
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "wwF" = (
 /turf/closed/indestructible/fakedoor{
@@ -17397,7 +17453,7 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "xnl" = (
 /obj/effect/turf_decal/sand,
@@ -17448,7 +17504,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "xpH" = (
 /obj/structure/table/wood,
@@ -17496,7 +17552,7 @@
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "xtR" = (
 /obj/structure/fans/tiny/invisible,
@@ -17547,7 +17603,7 @@
 /area/centcom/interlink)
 "xzh" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "xzt" = (
 /obj/structure/chair/sofa/bench{
@@ -17859,7 +17915,7 @@
 "xXc" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "xXU" = (
 /obj/effect/turf_decal/siding/wood{
@@ -17921,7 +17977,7 @@
 	dir = 8
 	},
 /obj/effect/light_emitter/interlink,
-/turf/open/floor/grass,
+/turf/open/misc/asteroid/snow/indestructible/planet,
 /area/centcom/interlink)
 "ycB" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -24011,7 +24067,7 @@ wwD
 wwD
 vat
 vat
-pPO
+iov
 dsH
 vat
 cNw
@@ -26832,7 +26888,7 @@ vat
 vat
 hbE
 vat
-pPO
+iov
 dVb
 iPs
 iPs
@@ -27607,7 +27663,7 @@ tvw
 vat
 vat
 cNw
-pPO
+iov
 eSk
 tvw
 qrv
@@ -30417,9 +30473,9 @@ tvw
 vLx
 vat
 vat
-vat
-vat
-adw
+uhT
+pPO
+cds
 aqG
 aqG
 aqG
@@ -30673,10 +30729,10 @@ aaa
 tvw
 vLx
 vat
-bnU
 vat
-sGU
-adw
+vat
+dky
+aqG
 aqG
 aqG
 aqG
@@ -30932,8 +30988,8 @@ vLx
 eSk
 vat
 vat
-vat
-adw
+pEO
+avt
 aqG
 aqG
 aqG
@@ -34838,7 +34894,7 @@ vat
 vat
 vat
 vat
-dky
+sZl
 dVb
 iPs
 iPs
@@ -35088,7 +35144,7 @@ dfL
 vat
 hbE
 vat
-iXq
+sZl
 iuK
 iuK
 rSa
@@ -35593,7 +35649,7 @@ tdp
 iem
 uaM
 iPs
-rDg
+eJZ
 hbE
 vat
 uKH
@@ -35850,7 +35906,7 @@ vLx
 vLx
 iPs
 qot
-vat
+rne
 hbE
 vat
 dVb
@@ -37146,7 +37202,7 @@ tvw
 vat
 vat
 vat
-lTP
+sZl
 vat
 vat
 vat
@@ -67719,7 +67775,7 @@ aIr
 aDC
 axT
 aGL
-rne
+aGL
 mYg
 aGC
 baM
@@ -68998,7 +69054,7 @@ ajj
 aAd
 aAd
 agU
-gtO
+iXq
 wfN
 wfN
 rXY
@@ -69512,7 +69568,7 @@ aAd
 aAd
 asX
 agU
-nXw
+lTP
 lro
 aIr
 aAh
@@ -69769,7 +69825,7 @@ aAd
 asX
 aAd
 agU
-nXw
+lTP
 aSt
 aSt
 aSt
@@ -70283,7 +70339,7 @@ ajj
 ajj
 aAd
 agU
-ayI
+aCX
 ayI
 ayI
 mSQ
@@ -72630,7 +72686,7 @@ gmU
 vTT
 bkt
 gyS
-avt
+amk
 ooY
 aAd
 dav


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

ahh, december. what a jolly time to be alive and play Iris Station.
the station is in space (as always). solgov is undergoing a political crisis (as always), and the Spinward cafe is
holy shit. what the fuck happened to the Spinward cafe

![Screenshot 2024-12-18 182337](https://github.com/user-attachments/assets/15cc0481-dc53-439d-a00f-992b5639face)

this PR makes the ghost cafe and centcom (interlink) grass snow for seasonal purposes
trees are replaced with pine trees, there's less jungle plants, and it's now canonically (not) New Moscow
this also tweaks some things in the ghost cafe by removing the paper telling you about the new areas. it's been there since the beginning and i'm sure nobody needs to see it anymore

## Why it's Good for the Game

christmas :) and mostly roleplay too if people want to use the interlink / ghost cafe for that (rp only happened once there and that was during the gateway test incident). it's best to keep our ghost cafe up to date and fresh with new visual changes to match the season (and we could always just revert the change anyway)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

it complied. ran fine when i played it
more screenshots are below

- [x] make ghost cafe snow
- [x] make centcom snow
- [x] add some tiny things and tweaks
- [x] please the linters (and assasinate the awful tree with the step_y step_x bs)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

ghost cafe:
![Screenshot 2024-12-18 182031](https://github.com/user-attachments/assets/72f99429-9d05-413b-97a1-b4c37cf9857e)
![Screenshot 2024-12-18 182132](https://github.com/user-attachments/assets/f48e147b-3818-4c8e-bfbe-dfc16b3b6f2d)
![Screenshot 2024-12-18 182053](https://github.com/user-attachments/assets/58e9246f-c20f-40a3-8d23-f09463be38bc)

interlink:
![Screenshot 2025-01-03 002530](https://github.com/user-attachments/assets/85eb79ba-d23b-4c84-936b-4865311de3d8)
![Screenshot 2025-01-03 002602](https://github.com/user-attachments/assets/bfb34481-2372-4760-b6f5-ce145809a62e)
![Screenshot 2025-01-03 002711](https://github.com/user-attachments/assets/2c45667f-c647-4f0d-8514-6d1e0165d4cb)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: A blizzard has affected the Ghost Cafe and Interlink areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
