### PR TITLE
Entombed Tweak: Plasmaman-Lite Accessibility

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -136,12 +136,17 @@
 	if (!modsuit) // really don't know how this could ever happen but it's better than runtimes
 		return
 	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/obj/item/mod/module/plasma_stabilizer/entombed/plasma_stab = new
 	if (isethereal(human_holder))
 		var/obj/item/mod/core/ethereal/eth_core = new
 		eth_core.install(modsuit)
-	else if (isplasmaman(human_holder))
-		var/obj/item/mod/module/plasma_stabilizer/entombed/plasma_stab = new
+	if (isplasmaman(human_holder)) // IRIS EDIT: Shifted var/.../plasma_stabilizer/entombed to above to reduce redundancy with addition below. retained species check as fallback
 		modsuit.install(plasma_stab, human_holder)
+	//IRIS ADDITION START: Check if quirk holder has Any plasma limbs, give them a stabilizer if so
+	for (var/obj/item/bodypart/part in human_holder.bodyparts)
+		if (part.limb_id == SPECIES_PLASMAMAN)
+			modsuit.install(plasma_stab, human_holder)
+	//IRIS ADDITION END
 
 /datum/quirk/equipping/entombed/proc/install_quirk_interaction_features()
 	// if entombed needs to interact with certain other quirks, add it here


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Grants the plasma stabilizer to any poor unfortunate soul who happens to both have the entombed quirk and a plasmaman limb.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Discord request

![image](https://github.com/user-attachments/assets/5c5fd9af-2035-4489-83db-f74873aa1149)

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<details>
<summary>Screenshots/Videos</summary>

Works with a single plasma limb,
![waow](https://github.com/user-attachments/assets/3763786f-e027-48d7-b013-7737fcc48b3e)
or with multiple! Waow
![based based based based based](https://github.com/user-attachments/assets/3b23a27e-edcf-4a0d-b06c-90150c200de9)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Nanotrasen discovered that letting their employees burn is actually less profitable than the alternative. Those with plasma-infested limbs have had their entombed-grade modsuits retrofitted with plasma stabilizers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
