### PR TITLE
I'll fix this later <- lie

### DIFF
--- a/modular_iris/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_iris/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -4,12 +4,12 @@
 	icon_state = "hair_hyenamane"
 	icon = 'modular_iris/icons/mob/species/human/humanface.dmi'
 
-/datum/sprite_accessory/hair/taggot_franny
+/datum/sprite_accessory/hair/tailhair
 	name = "Tail Hair"
 	icon_state = "hair_tailhair"
 	icon = 'modular_iris/icons/mob/species/human/humanface.dmi'
 
-/datum/sprite_accessory/hair/whor_eee
+/datum/sprite_accessory/hair/hairfre
 	name = "Hairfre"
 	icon_state = "hair_hairfre"
 	icon = 'modular_iris/icons/mob/species/human/humanface.dmi'
@@ -172,6 +172,13 @@
 	name = "Teshari (Stubby)"
 	icon = 'modular_iris/master_files/icons/mob/sprite_accessory/tails.dmi'
 	icon_state = "teshari_stubby"
+
+//moved from modular_nova/.../sprite_accessories to keep "none" at the top of our wing selection list
+
+/datum/sprite_accessory/wings/none
+	name = SPRITE_ACCESSORY_NONE
+	icon_state = "none"
+	factual = FALSE
 
 //moth wings - apparently Nova uses /datum/sprite_accessory/wings/moth/ and not /datum/sprite_accessory/moth_wings/
 

--- a/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_nova/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -56,10 +56,7 @@
 
 	return TRUE
 
-/datum/sprite_accessory/wings/none
-	name = SPRITE_ACCESSORY_NONE
-	icon_state = "none"
-	factual = FALSE
+// moved /datum/sprite_accessory/wings/none to modular_iris/.../sprite_accessories to keep "none" at the top of our wing selection list
 
 /*
 *	FLIGHT POTION WINGS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shifts the "None" wing option towards the top of the list. It isn't _at_ the top because of some tg/nova bullshit that I don't want to untangle right now. 
I'll fix this later <- lie
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
It sucked that the "None" option for wings wasn't visible without scrolling.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
What Ever Who Care

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The "None" option for wings is once again near the top of the list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
