### PR TITLE
[PORT] Assorted Entombed Buffs

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -8,17 +8,35 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF // It is better to die for the Emperor than live for yourself.
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
-	charge_drain = DEFAULT_CHARGE_DRAIN
+	complexity_max = DEFAULT_MAX_COMPLEXITY //IRIS EDIT: Increased complexity to base value (Assorted Entombed Buffs)
+	charge_drain = DEFAULT_CHARGE_DRAIN * 0.6  // IRIS EDIT: Slower charge drain (Assorted Entombed Buffs)
 	slowdown_inactive = 2.5 // very slow because the quirk infers you rely on this to move/exist
-	slowdown_active = 0.95
+	slowdown_active = 0.5 // IRIS EDIT: Reduced slowdown (Assorted Entombed Buffs)
+	//IRIS EDIT: Removed joint torsion to balance around new charge drain, added basic EMP Protections and Status Readout (Assorted Entombed Buffs)
 	inbuilt_modules = list(
-		/obj/item/mod/module/joint_torsion/entombed,
 		/obj/item/mod/module/storage,
+		/obj/item/mod/module/status_readout/entombed,
+		/obj/item/mod/module/emp_shield/entombed,
 	)
+	//IRIS EDIT: Buffed entombed storage to be compatible with most jobs (Assorted Entombed Buffs)
 	allowed_suit_storage = list(
-		/obj/item/tank/internals,
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing,
 		/obj/item/flashlight,
+		/obj/item/gun,
+		/obj/item/melee,
+		/obj/item/tank/internals,
+		/obj/item/storage/belt/holster,
+		/obj/item/construction,
+		/obj/item/fireaxe,
+		/obj/item/pipe_dispenser,
+		/obj/item/storage/bag,
+		/obj/item/pickaxe,
+		/obj/item/resonator,
+		/obj/item/t_scanner,
+		/obj/item/analyzer,
+		/obj/item/storage/medkit,
+		/obj/item/fireaxe/metal_h2_axe,
 	)
 
 /datum/armor/mod_entombed
@@ -27,17 +45,14 @@
 	laser = ARMOR_LEVEL_WEAK
 	energy = ARMOR_LEVEL_WEAK
 	bomb = ARMOR_LEVEL_WEAK
-	bio = ARMOR_LEVEL_WEAK
+	bio = 100 // IRIS EDIT: Increased value to envirosuit levels (Assorted Entombed Buffs)
 	fire = ARMOR_LEVEL_WEAK
 	acid = ARMOR_LEVEL_WEAK
 	wound = WOUND_ARMOR_WEAK
 
-/obj/item/mod/module/joint_torsion/entombed
-	name = "internal joint torsion adaptation"
-	desc = "Your adaptation to life in this MODsuit shell allows you to ambulate in such a way that your movements recharge the suit's internal batteries slightly, but only while under the effect of gravity."
-	removable = FALSE
-	complexity = 0
-	power_per_step = DEFAULT_CHARGE_DRAIN * 0.4
+//IRIS EDIT: Kills /obj/item/mod/module/joint_torsion/entombed
+
+// ENTOMBED SPECIALTY MODULES
 
 /obj/item/mod/module/plasma_stabilizer/entombed
 	name = "colony-stabilized interior seal"
@@ -45,6 +60,22 @@
 	complexity = 0
 	idle_power_cost = 0
 	removable = FALSE
+
+/obj/item/mod/module/anomaly_locked/antigrav/entombed
+	name = "assistive anti-gravity ambulator"
+	desc = "An obligatory addition from the NanoTrasen science division as part of the Space Disabilities Act, this augmentation allows your suit to project a limited anti-gravity field to aid in your ambulation around the station for both general use and emergencies. It is powered by a tiny sliver of a gravitational anomaly core, inextricably linked to the power systems that keep you alive. Warning: not rated for EMP protection."
+	complexity = 1
+	allow_flags = MODULE_ALLOW_INACTIVE // the suit is never off, so this just allows this to be used w/o being parts-deployed for cosmetic reasons
+	removable = FALSE
+	active_power_cost = 0
+	prebuilt = TRUE
+	core_removable = FALSE
+
+/obj/item/mod/module/status_readout/entombed
+	use_energy_cost = 0
+
+/obj/item/mod/module/emp_shield/entombed
+	idle_power_cost = 0
 
 // ENTOMBED MOD CLOTHING COMPONENT
 
@@ -76,15 +107,6 @@
 	if (!isnull(piece))
 		piece.doMove(host_suit)
 
-/obj/item/mod/module/anomaly_locked/antigrav/entombed
-	name = "assistive anti-gravity ambulator"
-	desc = "An obligatory addition from the NanoTrasen science division as part of the Space Disabilities Act, this augmentation allows your suit to project a limited anti-gravity field to aid in your ambulation around the station for both general use and emergencies. It is powered by a tiny sliver of a gravitational anomaly core, inextricably linked to the power systems that keep you alive. Warning: not rated for EMP protection."
-	complexity = 1
-	allow_flags = MODULE_ALLOW_INACTIVE // the suit is never off, so this just allows this to be used w/o being parts-deployed for cosmetic reasons
-	removable = FALSE
-	active_power_cost = 0 // torsion does not generate power in antigrav, so this is effectively -0.4 * DEFAULT_CHARGE_DRAIN
-	prebuilt = TRUE
-	core_removable = FALSE
 
 // MOD CONTROL UNIT
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/DopplerShift13/DopplerShift/pull/301, minus the extra sprites
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
While the Entombed is a quirk intended to be a sort of challenge mode, we have enough players who use it at this point that I think it's worth making it a little less unbearable to play. There's no reason for job-related items to not fit in their storage, for example, and I can't think of a solid reason why having to go to a charging port every five minutes is engaging gameplay.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Entombed suits now require less charge to function, are less sluggish when active, can fit most job-related items in their storage, and have basic EMP protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
