### PR TITLE
Tweaks the crusher mark to be less painful

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -355,7 +355,7 @@
 	/// If the projectile that applies this was boosted, the mark will also be boosted
 	var/boosted = FALSE
 	/// How long before the mark is ready to be detonated. Used for both the visual overlay and to determine when it's ready
-	var/ready_delay = 0.5 SECONDS
+	var/ready_delay = 0.5 SECONDS /// Buffed from .8 seconds for Iris. -DH
 	/// Tracks world.time when the mark was applied
 	var/mark_applied
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

just a minor number change, reducing the wait on crusher marks to .5 from .8
## Why it's Good for the Game

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Almost everyone that uses the crusher feels that it is a lot clunkier now due to the delay between crusher mark being greater than original, given that it had a minimum half a second before it could hit.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: rreduced the PKC mark "warmup" to half a second, down from 0.8 seconds. Should make hitting your marked targets a little more responsive feeling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
