### PR TITLE
Various Borer changes and mapped in eggs

### DIFF
--- a/_maps/iris/automapper/templates/VoidRaptor/voidraptor_experimentor_room.dmm
+++ b/_maps/iris/automapper/templates/VoidRaptor/voidraptor_experimentor_room.dmm
@@ -1,0 +1,113 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"e" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/smooth_edge,
+/area/station/science/explab)
+"f" = (
+/turf/open/floor/engine,
+/area/station/science/explab)
+"m" = (
+/obj/structure/table/reinforced,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/turf/open/floor/engine,
+/area/station/science/explab)
+"s" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+"C" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Research Test Chamber";
+	req_access = list("science")
+	},
+/turf/open/floor/engine,
+/area/station/science/explab)
+"E" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/engine,
+/area/station/science/explab)
+"J" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 1
+	},
+/area/station/science/explab)
+"X" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/item/relic,
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 17
+	},
+/obj/item/taperecorder{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
+
+(1,1,1) = {"
+a
+a
+m
+E
+s
+X
+"}
+(2,1,1) = {"
+a
+a
+f
+C
+e
+J
+"}
+(3,1,1) = {"
+a
+a
+a
+a
+a
+a
+"}
+(4,1,1) = {"
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/iris/automapper/templates/deltastation/deltastation_experimentor_room.dmm
+++ b/_maps/iris/automapper/templates/deltastation/deltastation_experimentor_room.dmm
@@ -1,0 +1,58 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"x" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/structure/table/reinforced,
+/obj/effect/mob_spawn/ghost_role/borer_egg{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/effect/mob_spawn/ghost_role/borer_egg{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/turf/open/floor/engine,
+/area/station/science/explab,
+/area/station/science/explab)
+
+(1,1,1) = {"
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+"}
+(4,1,1) = {"
+a
+a
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+"}
+(6,1,1) = {"
+a
+x
+a
+"}
+(7,1,1) = {"
+a
+a
+a
+"}

--- a/_maps/iris/automapper/templates/deltastation/deltastation_experimentor_room.dmm
+++ b/_maps/iris/automapper/templates/deltastation/deltastation_experimentor_room.dmm
@@ -18,7 +18,6 @@
 	},
 /obj/effect/mob_spawn/ghost_role/borer_egg,
 /turf/open/floor/engine,
-/area/station/science/explab,
 /area/station/science/explab)
 
 (1,1,1) = {"

--- a/_maps/iris/automapper/templates/metastation/metastation_experimentor_room.dmm
+++ b/_maps/iris/automapper/templates/metastation/metastation_experimentor_room.dmm
@@ -1,0 +1,46 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"S" = (
+/obj/structure/table/reinforced,
+/obj/effect/mob_spawn/ghost_role/borer_egg{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/effect/mob_spawn/ghost_role/borer_egg{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/turf/open/floor/engine,
+/area/station/science/explab)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+a
+S
+a
+"}
+(4,1,1) = {"
+a
+a
+a
+a
+a
+"}

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -14452,6 +14452,10 @@
 /obj/structure/sign/poster/random/directional/south,
 /obj/effect/turf_decal/tile/dark_purple/anticorner/contrasted,
 /obj/effect/turf_decal/tile/dark_purple,
+/obj/structure/table/reinforced,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
 "exz" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -50669,6 +50669,10 @@
 "nEt" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/machinery/light/directional/south,
+/obj/structure/table/reinforced,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
+/obj/effect/mob_spawn/ghost_role/borer_egg,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/science/explab)
 "nEu" = (

--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -59,6 +59,14 @@ required_map = "MetaStation.dmm"
 coordinates = [72, 186, 1]
 trait_name = "Station"
 
+# Iris - Metastation Borer Eggs
+[templates.metastation_experimentor_room]
+map_files = ["metastation_experimentor_room.dmm"]
+directory = "_maps/iris/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [133, 102, 1]
+trait_name = "Station"
+
 # Metastation Barber
 [templates.metastation_barber]
 map_files = ["metastation_barber.dmm"]
@@ -130,6 +138,14 @@ map_files = ["deltastation_arcmining.dmm"]
 directory = "_maps/iris/automapper/templates/deltastation/"
 required_map = "DeltaStation2.dmm"
 coordinates = [171, 154, 1]
+trait_name = "Station"
+
+# Iris - Deltastation Borer Eggs
+[templates.deltastation_experimentor_room]
+map_files = ["deltastation_experimentor_room.dmm"]
+directory = "_maps/iris/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [116, 101, 1]
 trait_name = "Station"
 
 # Deltastation Barber
@@ -560,4 +576,12 @@ map_files = ["voidraptor_medbay_cold_room.dmm"]
 directory = "_maps/iris/automapper/templates/VoidRaptor/"
 required_map = "VoidRaptor.dmm"
 coordinates = [77, 101, 1]
+trait_name = "Station"
+
+# Iris - VoidRaptor Borer Room
+[templates.VoidRaptor_experimentor_room]
+map_files = ["voidraptor_experimentor_room.dmm"]
+directory = "_maps/iris/automapper/templates/VoidRaptor/"
+required_map = "VoidRaptor.dmm"
+coordinates = [88, 177, 1]
 trait_name = "Station"

--- a/modular_nova/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer.dm
@@ -1,8 +1,8 @@
-GLOBAL_VAR_INIT(objective_egg_borer_number, 2)
-GLOBAL_VAR_INIT(objective_egg_egg_number, 5)
-GLOBAL_VAR_INIT(objective_willing_hosts, 2)
-GLOBAL_VAR_INIT(objective_blood_chem, 3)
-GLOBAL_VAR_INIT(objective_blood_borer, 3)
+GLOBAL_VAR_INIT(objective_egg_borer_number, 0)
+GLOBAL_VAR_INIT(objective_egg_egg_number, 0)
+GLOBAL_VAR_INIT(objective_willing_hosts, 0)
+GLOBAL_VAR_INIT(objective_blood_chem, 0)
+GLOBAL_VAR_INIT(objective_blood_borer, 0)
 
 GLOBAL_VAR_INIT(successful_egg_number, 0)
 GLOBAL_LIST_EMPTY(willing_hosts)
@@ -114,7 +114,6 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 										/datum/reagent/lithium,
 										/datum/reagent/medicine/salglu_solution,
 										/datum/reagent/medicine/mutadone,
-										/datum/reagent/toxin/heparin,
 										/datum/reagent/drug/methamphetamine/borer_version,
 										/datum/reagent/medicine/morphine,
 										/datum/reagent/medicine/inacusiate,
@@ -212,12 +211,6 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 
 /mob/living/basic/cortical_borer/Initialize(mapload)
 	. = ..()
-	AddComponent( \
-		/datum/component/squashable, \
-		squash_chance = 25, \
-		squash_damage = 25, \
-		squash_flags = SQUASHED_DONT_SQUASH_IN_CONTENTS, \
-	)
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT) //they need to be able to move around
 
 	var/matrix/borer_matrix = matrix(transform)

--- a/modular_nova/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer.dm
@@ -330,7 +330,7 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 		return
 	if(ckey || key)
 		return
-	to_chat(user, span_warning("As a borer, you have the option to be friendly or not. Note that how you act will determine how a host responds!"))
+	to_chat(user, span_warning("As a borer, you have the option to help antagonists or not. Note that how you act will determine how a host responds!"))
 	to_chat(user, span_warning("You are a cortical borer! You can fear someone to make them stop moving, but make sure to inhabit them! You only grow/heal/talk when inside a host!"))
 	ckey = user.ckey
 	if(mind)

--- a/modular_nova/modules/cortical_borer/code/cortical_borer_abilities.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer_abilities.dm
@@ -658,8 +658,6 @@
 					cortical_owner.human_host.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_SURGERY)
 				if(61 to 71)
 					cortical_owner.human_host.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
-				if(72 to 75)
-					cortical_owner.human_host.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
 	to_chat(cortical_owner.human_host, span_warning("Your brain begins to hurt..."))
 	var/turf/borer_turf = get_turf(cortical_owner)
 	new /obj/effect/decal/cleanable/vomit(borer_turf)

--- a/modular_nova/modules/cortical_borer/code/cortical_borer_egg.dm
+++ b/modular_nova/modules/cortical_borer/code/cortical_borer_egg.dm
@@ -14,9 +14,9 @@
 	you_are_text = "You are a Cortical Borer."
 	flavour_text = "You are a cortical borer! You can fear someone to make them stop moving, but make sure to inhabit them! \
 					You only grow/heal/talk when inside a host!"
-	important_text = "As a borer, you have the option to be friendly or not. \
+	important_text = "As a borer, you have the option to help antagonists or not. \
 					Note that how you act will determine how a host responds. \
-					Do not wordlessly resort to mechanics within a host. \
+					Do not enter hosts with an intent to harm. \
 					You can talk to other borers using ; and your host by just speaking normally. \
 					You are unable to speak outside of a host, but are able to emote."
 	///what the generation of the borer egg is

--- a/modular_nova/modules/cortical_borer/code/evolution/evolution_datum.dm
+++ b/modular_nova/modules/cortical_borer/code/evolution/evolution_datum.dm
@@ -33,6 +33,6 @@
 	tier = 0
 	unlocked_evolutions = list(
 		/datum/borer_evolution/upgrade_injection,
-		/datum/borer_evolution/symbiote/willing_host,
+		/datum/borer_evolution/symbiote/minor_chemicals,
 		/datum/borer_evolution/hivelord/produce_offspring,
 	)

--- a/modular_nova/modules/cortical_borer/code/evolution/evolution_hivelord.dm
+++ b/modular_nova/modules/cortical_borer/code/evolution/evolution_hivelord.dm
@@ -33,7 +33,7 @@
 	name = "Increased Energy"
 	desc = "Boost your speed by a large amount."
 	gain_text = "And as I watched, the Cortical Borer was able to complete the course in just over half the time it had last week."
-	mutually_exclusive = TRUE
+	mutually_exclusive = FALSE
 	tier = 3
 	unlocked_evolutions = list(/datum/borer_evolution/hivelord/stealth_mode)
 
@@ -65,7 +65,7 @@
 		/datum/borer_evolution/sugar_immunity,
 		/datum/borer_evolution/synthetic_borer,
 		/datum/borer_evolution/synthetic_chems_positive,
-		/datum/borer_evolution/synthetic_chems_negative,
+		// /datum/borer_evolution/synthetic_chems_negative,
 	)
 
 /datum/borer_evolution/hivelord/produce_offspring_alone/on_evolve(mob/living/basic/cortical_borer/cortical_owner)

--- a/modular_nova/modules/cortical_borer/code/evolution/evolution_symbiote.dm
+++ b/modular_nova/modules/cortical_borer/code/evolution/evolution_symbiote.dm
@@ -2,18 +2,24 @@
 	evo_type = BORER_EVOLUTION_SYMBIOTE
 
 // T1
-/datum/borer_evolution/symbiote/willing_host
-	name = "Willing Host"
-	desc = "Ask a host if they are willing, furthering your objectives."
+/datum/borer_evolution/symbiote/minor_chemicals
+	name = "Minor Chemicals"
+	desc = "Gain some minor benifical chemicals."
 	gain_text = "Some of the monkeys we gave the worms seemed far more... willing than others to be a host. I could've sworn one let them climb up their arm."
 	tier = 1
 	unlocked_evolutions = list(/datum/borer_evolution/symbiote/chem_per_level)
 	evo_cost = 1
 
-/datum/borer_evolution/symbiote/willing_host/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
+	var/static/list/added_chemicals = list(
+		/datum/reagent/medicine/coagulant,
+		/datum/reagent/medicine/psicodine,
+		/datum/reagent/medicine/granibitaluri,
+		/datum/reagent/consumable/ethanol,
+	)
+
+/datum/borer_evolution/symbiote/minor_chemicals/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
-	var/datum/action/cooldown/borer/willing_host/attack_action = new(cortical_owner)
-	attack_action.Grant(cortical_owner)
+	cortical_owner.potential_chemicals |= added_chemicals
 
 // T2
 /datum/borer_evolution/symbiote/chem_per_level
@@ -34,7 +40,7 @@
 	name = "Expanded Chemical List"
 	desc = "Gain access to a new list of helpful chemicals to the unlockable list."
 	gain_text = "The chemicals the worms seem capable of synthesizing are truly remarkable, their hosts are able to get up from amazing amounts of harm."
-	mutually_exclusive = TRUE
+	mutually_exclusive = FALSE
 	tier = 3
 	unlocked_evolutions = list(
 		/datum/borer_evolution/symbiote/harm_decrease,

--- a/modular_nova/modules/cortical_borer/code/evolution/evolution_symbiote.dm
+++ b/modular_nova/modules/cortical_borer/code/evolution/evolution_symbiote.dm
@@ -5,7 +5,7 @@
 /datum/borer_evolution/symbiote/minor_chemicals
 	name = "Minor Chemicals"
 	desc = "Gain some minor benifical chemicals."
-	gain_text = "Some of the monkeys we gave the worms seemed far more... willing than others to be a host. I could've sworn one let them climb up their arm."
+	gain_text = "Some of the monkeys we gave the worms seemed far more... drunk than others after the worms got in."
 	tier = 1
 	unlocked_evolutions = list(/datum/borer_evolution/symbiote/chem_per_level)
 	evo_cost = 1

--- a/tgui/packages/tgui/interfaces/BorerEvolution.tsx
+++ b/tgui/packages/tgui/interfaces/BorerEvolution.tsx
@@ -22,8 +22,8 @@ type Evolution = {
 };
 
 type EvolutionInfo = {
-  learnableEvolution: Evolution[];
-  learnedEvolution: Evolution[];
+  learnableEvolution: Evolution[] | undefined;
+  learnedEvolution: Evolution[] | undefined;
 };
 
 type Info = {
@@ -52,8 +52,8 @@ const PastEvolutions = (props) => {
     <Stack.Item grow>
       <Section title="Past Evolutions" fill scrollable>
         <Stack vertical>
-          {(!learnedEvolution.length && 'None!') ||
-            learnedEvolution.map((learned) => (
+          {(!learnedEvolution?.length && 'None!') ||
+            learnedEvolution?.map((learned) => (
               <Stack.Item key={learned.name}>
                 <Button
                   width="100%"
@@ -78,8 +78,8 @@ const EvolutionList = (props) => {
   return (
     <Stack.Item grow>
       <Section title="Possible Evolutions" fill scrollable>
-        {(!learnableEvolution.length && 'None!') ||
-          learnableEvolution.map((toLearn) => (
+        {(!learnableEvolution?.length && 'None!') ||
+          learnableEvolution?.map((toLearn) => (
             <Stack.Item key={toLearn.name} mb={1}>
               <Button
                 width="100%"


### PR DESCRIPTION
## About The Pull Request
John Borer made this pr with a bunch of borer changes and now I have to pr this help-
So, this does a LOT. Firstly, there are now guaranteed borer eggs in every (currently in rotation) map, located in each Experimentor room. Why there? It was easier than basically redoing a bunch of xenobio pens on each map.
Next, Borers have lost the ability to be squished like cockroaches. It makes sense as an antagonists counter measure, but not as something friendly to willing hosts. I have also changed their ghost role menu text to reflect this. They can infest antagonists, but cannot directly harm their hosts under their antagonists orders. Do note that currently, the eggs don't have objectives when they spawn. If I knew how, I'd give them something like "Do not harm your hosts". I also set the borer minimum required for borers to "win" at 0 for all settings. since I was worried about breaking stuff by just removing it.
I added the ability for borers to cross path, since Hivelord is basically useless path compared to symbiote.
Finally, I replaced T1 Symbiote with some more chemicals, nothing too crazy just Sanguirite. Psicodine, Granibitaluri, and Ethanol. Also changed the text to reflect this
EDIT: I forgor to kill the deep-rooted stuff so I'm doing it now :3
## Why it's Good for the Game
Borers aren't antags anymore, so I don't see why we can't map them into existence instead of the occasional admin event or something. As for the changes, helps them be supportive of their hosts.
## Proof of Testing
![YpJepoFbHu](https://github.com/user-attachments/assets/36ec0222-9c73-4bbb-ba0b-19a7f0a8792d)
![PrFyrKtOzR](https://github.com/user-attachments/assets/a587b3de-69d3-4a6e-902d-18b4bee51814)
![dreamseeker_pvb1m4tFsQ](https://github.com/user-attachments/assets/2e0baae2-27b2-4202-ace3-d6d19cb3ced4)
I can't prove that I tested the no squash thing, but I assure you I did
## Changelog

:cl:
add: More chemicals for Borers to learn
add: Borers can cross path now, Yippee!
del: Borers cannot get squished like cockroaches anymore
del: Deep-rooted trauma should no longer appear when borers lay eggs
map: Added Borer eggs to every map that's in rotation
/:cl: