### PR TITLE
Traffic Control Console Logs Timestamp Fix

### DIFF
--- a/modular_iris/modules/NTSL/code/machinery/traffic_control.dm
+++ b/modular_iris/modules/NTSL/code/machinery/traffic_control.dm
@@ -63,7 +63,7 @@
 /obj/machinery/computer/telecomms/traffic/proc/create_log(entry)
 	if(!user_name)
 		CRASH("[type] tried to create a log with no user_name!")
-	access_log += "\[[get_timestamp()]\] [user_name] [entry]"
+	access_log += "\[[time_stamp()]\] [user_name] [entry]"
 
 /obj/machinery/computer/telecomms/traffic/ui_interact(mob/user, datum/tgui/ui)
 	if(is_banned_from(user.ckey, JOB_TELECOMMS_SPECIALIST))
@@ -116,7 +116,7 @@
 		var/message = "[key_name_admin(usr)] has completelly cleared the NTSL console of code and re-compiled as an admin, this should only be done in severe rule infractions."
 		message_admins(message)
 		logger.Log(LOG_NTSL, "[key_name(src)] [message] [loc_name(src)]")
-		access_log += "\[[get_timestamp()]\] ERR !NTSL REMOTELLY CLEARED BY NANOTRASEN STAFF!"
+		access_log += "\[[time_stamp()]\] ERR !NTSL REMOTELLY CLEARED BY NANOTRASEN STAFF!"
 		return TRUE
 	if(.)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The TCC's logs timestamps currently only include the seconds field.

![image](https://github.com/user-attachments/assets/2b7597f8-b224-4cbb-be84-734b8579d031)

This was caused by using the incorrect timestamp function, as shown below.

![image](https://github.com/user-attachments/assets/5e5aa8af-68e8-4cc8-97d4-2857ce932a99)

## Why it's Good for the Game

Bugfix: Log timestamps include a meaningful passage of time

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

![image](https://github.com/user-attachments/assets/e74a8704-ae3e-4d03-8887-5cb16afe9327)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TCC log timestamps show hour, minute, second
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
