### PR TITLE
Adds species quirks blacklists

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -33,6 +33,9 @@
 	/// The base weight for the each quirk's mail goodies list to be selected is 5
 	/// then the item selected is determined by pick(selected_quirk.mail_goodies)
 	var/list/mail_goodies
+	// IRIS EDIT quirk species locks
+	/// List of species types that are not allowed to have this quirk
+	var/list/disabled_species = list()
 
 /datum/quirk/Destroy()
 	if(quirk_holder)

--- a/code/datums/quirks/negative_quirks/blood_deficiency.dm
+++ b/code/datums/quirks/negative_quirks/blood_deficiency.dm
@@ -8,6 +8,7 @@
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
 	hardcore_value = 8
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
+	disabled_species = list(/datum/species/synthetic)
 	/// Minimum amount of blood the paint is set to
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -514,6 +514,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/validate_quirks()
 	if(CONFIG_GET(flag/disable_quirk_points))
 		return
+
+	for(var/quirk_name in all_quirks)
+		var/datum/quirk/quirk_type = SSquirks.quirks[quirk_name]
+		var/datum/species/species = read_preference(/datum/preference/choiced/species)
+		if(species in initial(quirk_type.disabled_species))
+			all_quirks -= quirk_name
+
 	if(GetQuirkBalance() < 0)
 		all_quirks = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a blacklist for quirks regarding to species. This makes it so you can't select the following quirks as these species:
```
Blood Deficiency = /datum/species/synthetic, /datum/species/pod, /datum/species/pod/podweak
System Shock = Literally all species that AREN'T /datum/species/synthetic
Food Allergy = /datum/species/synthetic
Body Purist = /datum/species/synthetic
Prosthetic Limb = /datum/species/synthetic
Extreme Medicine Allergy = /datum/species/synthetic
```
This is done so you can't just get free quirk points

TODO

- [ ] Figure out a good way on how to do system shock without writing out all species

- [ ] Add all the lists to the quirks

- [ ] *Maybe* Fix the visual bug of negative points somehow but it seems like this is a bug that is caused by the menu just being quite bad

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
It's not nice to have free quirk points or to have quirks that will just instantly demoralize you (body purist and synth lmao)
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
Tested it, found a bug
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Some species now can't take certain quirks anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
