### PR TITLE
NTSL Achievements Fix

### DIFF
--- a/modular_iris/modules/NTSL/code/machinery/server.dm
+++ b/modular_iris/modules/NTSL/code/machinery/server.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_EMPTY(tcomms_servers)
 	if(!length(compileerrors) && (compiledcode != rawcode))
 		user.log_message(rawcode, LOG_NTSL)
 		compiledcode = rawcode
-	if(user.mind.assigned_role == JOB_TELECOMMS_SPECIALIST) //achivement description says only Signal Technician gets the achivement
+	if(user.mind.assigned_role.title == JOB_TELECOMMS_SPECIALIST) //achivement description says only Signal Technician gets the achivement
 		var/freq = length(freq_listening[1]) ? freq_listening[1] : 1459
 		var/atom/movable/M = new()
 		var/atom/movable/virtualspeaker/speaker = new(null, M, server_radio)
@@ -84,7 +84,7 @@ GLOBAL_LIST_EMPTY(tcomms_servers)
 			signal.data["name"] = ""
 			signal.data["reject"] = FALSE
 			Compiler.Run(signal)
-			if(!signal.data["reject"] == FALSE)
+			if(signal.data["reject"] == FALSE)
 				user.client.give_award(/datum/award/achievement/jobs/Poly_silent, user)
 		else
 			for(var/sample in signal.data["spans"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It seemed suspicious that no one had either of the NTSL achievements yet, so I took a look at what the code was doing on a separate branch.

The first issue was that when checking if the player uploading the NTSL script is a Telecomms Specialist, the code was comparing the player's job datatype with the Telecomms Specialist job name string.  This will always return false.

![image](https://github.com/user-attachments/assets/a071913b-abe3-454b-8089-222aefd42e58)
![image](https://github.com/user-attachments/assets/b4fce11f-91f1-46e3-acc9-e9eb876a59c2)

The second issue is only for the achievement for blocking Poly on comms.  The intended checks for this are, to check that Poly is blocked, then check that a nameless user is not blocked.  The second check had a double negation on it, so the achievement was only given if effectively all users were blocked from comms.  This is clearly not the intended behavior.

Known corner case: The achievement for making Poly loud, will be awarded even if everyone on comms is made loud.  While this feels against the point of the achievement, I don't think this should be prevented, as the goal was adequately satisfied.

Known Issue: The 8 servers compile the code all at the same time, before each trying to award one of the achievements.  This means either achievement will be awarded 8 times.  This spams chat and the End of Round Summary, but otherwise appears harmless.  It does not inflate the achievement score, and it does not add extra rows to the achievements table.  

![image](https://github.com/user-attachments/assets/358b5e51-64c9-4a5b-b6d1-a1579a8f893b)
![image](https://github.com/user-attachments/assets/f7aa13a6-6ad4-41d0-a874-685f23c95675)
![image](https://github.com/user-attachments/assets/d3c94cb9-1e10-4d20-86dc-54936090efa2)
![image](https://github.com/user-attachments/assets/d468ec0f-d3d3-4ad7-8be9-d5423779ac24)

I can think of 2 potential solutions:
1) Restrict the achievements to a specific radio channel.  But this can cause confusion if Poly is put on a different channel, or if tcomms has been rebuilt from scratch.
2) Use a mutex so only one tcomms server is allowed to call give_award() at a time.  At this time, I don't know if DM supports mutex's or how one would correctly implement their behavior in DM.  I may look into this in the future.

## Why it's Good for the Game

Bugfix: broken achievements are now available

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

I am using an alt title to prove the achievements are still awarded while using them:
![image](https://github.com/user-attachments/assets/5cede086-5ce2-4f51-aebe-b11465003f94)

Silence Bird:

<details>
  <summary>NTSL Code</summary>
    ![image](https://github.com/user-attachments/assets/f1ee297b-4883-4749-b733-a67edad5018a)
</details>

![image](https://github.com/user-attachments/assets/8c33a79f-3d26-4011-a06f-798d7b3c9fa7)

Embrace The Bird:

<details>
  <summary>NTSL Code</summary>
    ![image](https://github.com/user-attachments/assets/207b95ed-25be-4da5-956d-1ac74b476109)
</details>

![image](https://github.com/user-attachments/assets/e0b0283d-f1b3-49a1-8e5b-9afe982452c2)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: NTSL achievements are now awardable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
