### PR TITLE
Preferences Occupation Page Widening Department on Alt Title Select Fix

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/JobsPage.tsx
@@ -331,21 +331,19 @@ function Department(props: DepartmentProps) {
 
   return (
     <Box>
-      <Stack vertical fill>
-        {jobsForDepartment.map(([name, job]) => {
-          return (
-            <JobRow
-              className={classes([
-                className,
-                name === department.head && 'head',
-              ])}
-              key={name}
-              job={job}
-              name={name}
-            />
-          );
-        })}
-      </Stack>
+      {jobsForDepartment.map(([name, job]) => {
+        return (
+          <JobRow
+            className={classes([
+              className,
+              name === department.head && 'head',
+            ])}
+            key={name}
+            job={job}
+            name={name}
+          />
+        );
+      })}
 
       {children}
     </Box>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In character preferences, on the occupations tab, when clicking on a job title to change it, the vertical width of each job in that job's department increases.

![image](https://github.com/user-attachments/assets/76198fce-0915-4b30-9758-34098c7cd293)

This behavior is not present on my branch from last week.  So I diffed the relevant file before and after the most recent change we put in.

![image](https://github.com/user-attachments/assets/e9064ede-ecd4-408f-8ee2-032402cfda2b)

The only obvious difference here is the Stack Vertical Fill tag.  Removing this appears to have resolved the issue.

## Why it's Good for the Game

Bugfix: UI doesn't grow unexpectedly when changing a job's alt title

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

The boxes have not grown when the alt title list was opened:

![image](https://github.com/user-attachments/assets/ad354470-c08c-4499-87ff-501dd3d4528a)

When clicked several times, the size has stayed the same.  I clicked every job for completeness.  (No way from image to tell I actually tested anything): 

![image](https://github.com/user-attachments/assets/a63ff9d1-851b-4781-8065-82d96df5722e)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: job box no longer grows when changing alt title
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
