### PR TITLE
DS-2 Door Bolts Fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -3375,7 +3375,8 @@
 /obj/machinery/button/door/directional/south{
 	id = "TESRedguard";
 	name = "Dorm Bolt Control";
-	specialfunctions = 4
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/nova/des_two/service/dorms)
@@ -6121,7 +6122,8 @@
 /obj/machinery/button/door/directional/north{
 	id = "TESBattlespire";
 	name = "Dorm Bolt Control";
-	specialfunctions = 4
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood/tile,
@@ -6632,7 +6634,8 @@
 /obj/machinery/button/door/directional/south{
 	id = "TESSkyrim";
 	name = "Restroom Bolt Control";
-	specialfunctions = 4
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/nova/des_two/service/diner)
@@ -7682,7 +7685,8 @@
 /obj/machinery/button/door/directional/north{
 	id = "TESArena";
 	name = "Dorm Bolt Control";
-	specialfunctions = 4
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/nova/des_two/service/dorms)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know the dorms and restroom in DS-2 don't actually bolt, despite having the buttons for it? That's because someone accidentally gave them blast door electronics instead of airlock electronics. Oops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Maps should work as intended.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![I am tired of Earth  These people  I am tired of being caught in the tangle of their lives](https://github.com/user-attachments/assets/26cea479-fd96-411f-809b-3db1f7b14cc7)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: DS-2's bedrooms and restroom have had their door bolts rewired, restoring their functionality.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
