### PR TITLE
Limbgrown Bodies port from bubber

### DIFF
--- a/modular_iris/code/modules/limbgrowncorpses/limbgrowerblanks.dm
+++ b/modular_iris/code/modules/limbgrowncorpses/limbgrowerblanks.dm
@@ -1,0 +1,26 @@
+// IRIS STATION PORT OF Limbgrown bodies from bubber
+// Used for printing dead bodies with the limbgrower
+/mob/living/carbon/human/empty
+
+/mob/living/carbon/human/empty/Initialize(mapload)
+	. = ..()
+	death()
+
+	var/obj/item/organ/brain/to_remove = get_organ_slot(ORGAN_SLOT_BRAIN)
+	qdel(to_remove)
+
+/datum/design/wholehuman
+	name = "Blank body"
+	id = "blankhuman"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 600)
+	build_path = /mob/living/carbon/human/empty
+	category = list(SPECIES_HUMAN, RND_CATEGORY_INITIAL)
+
+/datum/design/humanoidbrain
+	name = "Blank brain"
+	id = "blankbrain"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 100)
+	build_path = /obj/item/organ/brain
+	category = list(SPECIES_HUMAN, RND_CATEGORY_INITIAL)

--- a/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
+++ b/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
@@ -33,7 +33,7 @@
 	/// Is the soul able to leave the soulcatcher?
 	var/able_to_leave = TRUE
 	/// Did the soul live within the round? This is checked if we want to transfer the soul to another body.
-	var/round_participant = FALSE
+	var/round_participant = TRUE //IRIS EDIT
 	/// Does the body need scanned?
 	var/body_scan_needed = FALSE
 

--- a/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
+++ b/modular_nova/modules/modular_implants/code/soulcatcher/soulcatcher_mob.dm
@@ -33,7 +33,7 @@
 	/// Is the soul able to leave the soulcatcher?
 	var/able_to_leave = TRUE
 	/// Did the soul live within the round? This is checked if we want to transfer the soul to another body.
-	var/round_participant = TRUE //IRIS EDIT
+	var/round_participant = TRUE //IRIS/BUBBER EDIT
 	/// Does the body need scanned?
 	var/body_scan_needed = FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6666,6 +6666,7 @@
 #include "modular_iris\code\modules\blooper\atoms_movable.dm"
 #include "modular_iris\code\modules\blooper\bark.dm"
 #include "modular_iris\code\modules\blooper\bark_list.dm"
+#include "modular_iris\code\modules\limbgrowncorpses\limbgrowerblanks.dm"
 #include "modular_iris\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "modular_iris\maps\biodome\area.dm"
 #include "modular_iris\maps\biodome\beach.dm"


### PR DESCRIPTION
## About The Pull Request
Basically just ports https://github.com/Bubberstation/Bubberstation/pull/1842
Allows you to print an entire human body (minus brain, print that separately!) for a lotta synth flesh. Useful for getting a new soul into a body when someone's been completely and utterly destroyed. Also allows soulcatcher ghosts without a body to enter into a RSD compatible brain!
## Why it's Good for the Game
I thought the soulcatcher ghosts restriction was lame honestly, and printing an entire person seems useful so you don't need to break into genetics for a new body.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![y6DOnMDwI0](https://github.com/user-attachments/assets/2ea631ac-8623-4217-bfc7-67f98f272c27)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added blanks to the limbgrower, for soul/brain transfer.
/:cl:
