### PR TITLE
Adds a Delete Button to Character Preference Page 

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -750,6 +750,18 @@ export function MainPage(props: MainPageProps) {
             <Stack.Divider />
             {prefPageContents}
           </Stack>
+          <Box my={0.5}>
+            <Button
+              color="red"
+              disabled={
+                Object.values(data.character_profiles).filter((name) => name)
+                  .length < 2
+              }
+              onClick={() => setDeleteCharacterPopupOpen(true)}
+            >
+              Delete Character
+            </Button>
+          </Box>
           {/* IRIS EDIT END: Swappable pref menus -SKYRAT PORT*/}
         </Stack.Item>
       </Stack>


### PR DESCRIPTION
## About The Pull Request
Adds a character delete button to the bottom of the character preferences page.
## Why it's Good for the Game
It adds in a way to delete your character and keep slots clean or free up another one when you need it.
## Proof of Testing
Made a character and deleted it.
Checked to see if the button would be disabled if only one character existed.
![image](https://github.com/user-attachments/assets/17702d6d-64f6-4c3b-a84b-15ca0fd2f8f8)
## Changelog
:cl:
add: Added a character delete button in the character preferences menu.
/:cl: