### PR TITLE
Makes Hyposprays default to 5u dose

### DIFF
--- a/modular_nova/modules/hyposprays/code/hypovials.dm
+++ b/modular_nova/modules/hyposprays/code/hypovials.dm
@@ -6,7 +6,7 @@
 	greyscale_config = /datum/greyscale_config/hypovial
 	fill_icon_state = "hypovial_fill"
 	spillable = FALSE
-	volume = 10 // IRIS EDIT
+	volume = 10 
 	amount_per_transfer_from_this = 5 // IRIS EDIT
 	possible_transfer_amounts = list(1,2,5,10)
 	fill_icon_thresholds = list(10, 25, 50, 75, 100)


### PR DESCRIPTION
## About The Pull Request
Basically a port of a Bubber pr https://github.com/Bubberstation/Bubberstation/pull/2303
All it does is make it so Hyposprays start at 5u instead of 10u
## Why it's Good for the Game
Makes it inline with things like drinking from a bottle or a syringe, and QOL since you don't need to adjust EVERY SINGLE VIAL you make to inject for 5u
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![1rfi204y1jt61](https://github.com/user-attachments/assets/c92c13d0-c6c4-4fe8-bd38-fc8325a61d12)

It compiles
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Hypovial dosage is now 5u by default
/:cl: