### PR TITLE
Gives ashwalkers a way to access most base reagents via a new chem

### DIFF
--- a/modular_iris/modules/transmutation_fluid/code/transmutation_fluid.dm
+++ b/modular_iris/modules/transmutation_fluid/code/transmutation_fluid.dm
@@ -1,0 +1,73 @@
+//Transmutation fluid, a chem that makes some reagents into certain base reagents!
+/datum/reagent/transmutation_fluid
+	name = "Transmutation Fluid"
+	description = "An odd fluid that can turn one reagent into a different base reagent. Commonly found with tribal chemists."
+	ph = 5
+	color = "#CC8899"
+	taste_description = "fruity transfiguration"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
+	metabolization_rate = 0.5 // fast
+
+/datum/chemical_reaction/transmutation_fluid
+	results = list(/datum/reagent/transmutation_fluid = 3)
+	required_reagents = list(/datum/reagent/consumable/entpoly = 1, /datum/reagent/medicine/omnizine = 1, /datum/reagent/consumable/tinlux = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/fuel
+	results = list(/datum/reagent/fuel = 2)
+	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/hydrogen = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/iodine
+	results = list(/datum/reagent/iodine = 1)
+	required_reagents = list(/datum/reagent/water/salt = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/bromine
+	results = list(/datum/reagent/bromine = 2)
+	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/chlorine = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/sulfur
+	results = list(/datum/reagent/sulfur = 2)
+	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/fluorine
+	results = list(/datum/reagent/fluorine = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/chlorine = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/copper
+	results = list(/datum/reagent/copper = 2)
+	required_reagents = list(/datum/reagent/iron = 1, /datum/reagent/gold = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/transmutation/acid
+	results = list(/datum/reagent/toxin/acid = 2)
+	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/uranium/radium = 1)
+	required_catalysts = list(/datum/reagent/transmutation_fluid = 1)
+	optimal_ph_min = 0
+	optimal_ph_max = 14
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER

--- a/modular_iris/modules/transmutation_fluid/code/transmutation_fluid.dm
+++ b/modular_iris/modules/transmutation_fluid/code/transmutation_fluid.dm
@@ -16,6 +16,7 @@
 	optimal_ph_max = 14
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_OTHER
 
+//Oil and hydrogen makes welding fuel
 /datum/chemical_reaction/transmutation/fuel
 	results = list(/datum/reagent/fuel = 2)
 	required_reagents = list(/datum/reagent/fuel/oil = 1, /datum/reagent/hydrogen = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6755,6 +6755,7 @@
 #include "modular_iris\modules\research\designs\misc_designs.dm"
 #include "modular_iris\modules\research\techweb\all_nodes.dm"
 #include "modular_iris\modules\sound\sounds.dm"
+#include "modular_iris\modules\transmutation_fluid\code\transmutation_fluid.dm"
 #include "modular_iris\monke_ports\code\game\turfs\open\floor\misc_floor.dm"
 #include "modular_iris\monke_ports\code\modules\aesthetics\mapping\tilecoloring.dm"
 #include "modular_iris\monke_ports\code\modules\buckshotroulette\buckshotroulette.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a new chemical made from Entropic Polypnium, Omnizine, and Tinea Luxor, called Transmutation Fluid. This handy chemical turns various chemicals into another base reagent. I will list all the recipes here, in al of which Transmutation Fluid is required as a catalyst.
Oil and Hydrogen turns into Welding fuel.
Saltwater on its own gets turned into Iodine.
Carbon and Chlorine make Bromine.
Phosphorus and Hydrogen make Sulfur.
Ethanol and Chlorine make Fluorine.
Iron and Gold make Copper.
Finally, Sulfur and Radium make Sulfuric acid
## Why it's Good for the Game
More consistent way to get certain chemicals for Tribals
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_bI9ebfMACC](https://github.com/user-attachments/assets/9b18437d-8258-4d9f-8882-ded39c36869a)

</details>

## Changelog
:cl:
add: Transfiguration Fluid, which allows you to turn certain chemicals into base reagents
/:cl: