### PR TITLE
Hires sisyphus onto the station's mining crew

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -774,6 +774,10 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/holding/cafe)
+"amL" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "amT" = (
 /obj/structure/flora/bush/flowers_br,
 /turf/open/misc/grass/planet,
@@ -1691,7 +1695,7 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "axQ" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -2057,6 +2061,9 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)
+"aAM" = (
+/turf/open/floor/wood,
+/area/centcom/interlink/departures)
 "aAO" = (
 /obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/wood,
@@ -2500,7 +2507,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "aGw" = (
 /obj/structure/flora/bush/reed,
 /turf/open/misc/beach/sand{
@@ -2827,7 +2834,7 @@
 	dir = 10
 	},
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "aKc" = (
 /turf/open/indestructible/cobble/side,
 /area/centcom/holding/cafepark)
@@ -3383,7 +3390,7 @@
 	req_access = list("bar")
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "aQz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
@@ -4288,7 +4295,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "baA" = (
 /obj/structure/chair/sofa/bamboo/left{
 	dir = 1
@@ -4384,6 +4391,9 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"biH" = (
+/turf/open/floor/iron,
+/area/centcom/interlink/departures)
 "bja" = (
 /obj/structure/railing/wooden_fencing,
 /obj/structure/railing/wooden_fencing{
@@ -4504,7 +4514,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bqT" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /turf/open/floor/fakebasalt,
@@ -4517,7 +4527,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bsj" = (
 /turf/open/floor/wood,
 /area/centcom/interlink/dorm_rooms)
@@ -4566,7 +4576,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "buX" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/indestructible/hoteltile{
@@ -4600,7 +4610,7 @@
 "bxj" = (
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bxz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4644,7 +4654,7 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bDa" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw{
 	dir = 8
@@ -4653,7 +4663,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bDM" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Communications Access"
@@ -4706,7 +4716,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bHC" = (
 /obj/structure/flora/bush/large{
 	icon_state = "bush3"
@@ -4727,6 +4737,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"bIC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/interlink/departures)
 "bIG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4766,7 +4782,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bLZ" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -4811,7 +4827,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bON" = (
 /obj/structure/chair/sofa/bench/corner{
 	dir = 1
@@ -4843,7 +4859,12 @@
 "bQZ" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"bRX" = (
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "bSf" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing{
@@ -4886,14 +4907,14 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bUg" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "bUH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -5076,6 +5097,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/interlink)
+"ceI" = (
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "cfs" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/remains/xeno/larva,
@@ -5083,7 +5108,7 @@
 /area/centcom/holding/cafepark)
 "cfu" = (
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cgU" = (
 /obj/effect/light_emitter/interlink,
 /turf/open/misc/grass/planet,
@@ -5114,7 +5139,7 @@
 "ckD" = (
 /obj/item/pillow,
 /turf/open/floor/carpet/red,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ckG" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -5243,11 +5268,11 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cuM" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cwh" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/showroomfloor,
@@ -5257,7 +5282,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cxU" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/showcase/fake_cafe_console,
@@ -5288,7 +5313,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "czF" = (
 /obj/machinery/door/airlock{
 	id_tag = "stall3";
@@ -5315,13 +5340,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cBR" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cBT" = (
 /obj/structure/spacevine,
 /obj/structure/alien/weeds,
@@ -5387,17 +5412,17 @@
 	dir = 6
 	},
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cIk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cKf" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cKZ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -5418,7 +5443,7 @@
 	},
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cMd" = (
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
@@ -5481,7 +5506,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cQH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5509,6 +5534,9 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
+"cVu" = (
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "cVK" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -5548,13 +5576,17 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafepark)
+"cXT" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "cYb" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "cYc" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -5615,7 +5647,7 @@
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dcP" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/all_access,
 /turf/open/floor/iron/showroomfloor,
@@ -5680,7 +5712,7 @@
 /obj/structure/flora/tree/jungle/style_4,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dkD" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Interlink Cell";
@@ -5688,7 +5720,7 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dkE" = (
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/duct,
@@ -5729,7 +5761,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dsH" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/light_emitter/interlink,
@@ -5753,7 +5785,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dwx" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron,
@@ -5800,7 +5832,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dAM" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -5827,7 +5859,7 @@
 "dDp" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dDF" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/indestructible/carpet,
@@ -5838,7 +5870,7 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dFF" = (
 /obj/structure/sign/directions/security{
 	dir = 8;
@@ -6013,7 +6045,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/very_dim/directional/north,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dUh" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -6063,7 +6095,7 @@
 	name = "Interlink Cafe"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "dYa" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/fakebasalt,
@@ -6077,18 +6109,22 @@
 "eaT" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ebz" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ecW" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"eeA" = (
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/carpet/red,
+/area/centcom/interlink/departures)
 "eeZ" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/indestructible/hotelwood,
@@ -6111,13 +6147,13 @@
 /obj/effect/turf_decal/siding/white,
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "egG" = (
 /obj/structure/table/optable,
 /obj/effect/spawner/surgery_tray/full,
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "egW" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -6174,6 +6210,13 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"eoj" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "eon" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -6218,11 +6261,11 @@
 "esD" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "esP" = (
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "etn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -6237,7 +6280,7 @@
 /obj/item/stack/sheet/mineral/stone,
 /obj/item/stack/sheet/mineral/stone,
 /turf/open/misc/dirt/planet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "evs" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6329,7 +6372,7 @@
 "eFV" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eGf" = (
 /obj/structure/toilet{
 	dir = 1
@@ -6396,7 +6439,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eLt" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Interlink Medbay"
@@ -6407,7 +6450,7 @@
 /obj/structure/sign/departments/medbay/alt/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/arrow_cw,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eLQ" = (
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 6
@@ -6488,7 +6531,7 @@
 "eRB" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eSk" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/effect/light_emitter/interlink,
@@ -6502,11 +6545,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eTo" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eTt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -6519,7 +6562,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eXg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
@@ -6545,7 +6588,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "eYX" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 4
@@ -6563,11 +6606,11 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "faN" = (
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fbn" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -6752,7 +6795,7 @@
 /area/centcom/holding/cafe)
 "fqg" = (
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fsl" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -6804,7 +6847,7 @@
 	greyscale_colors = "#AA8A61"
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fza" = (
 /obj/structure/dresser{
 	icon = 'icons/obj/antags/abductor.dmi';
@@ -6898,12 +6941,12 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fHA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fHV" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/effect/light_emitter/interlink,
@@ -7063,7 +7106,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fTV" = (
 /obj/structure/spacevine{
 	name = "thick vines";
@@ -7101,7 +7144,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "fXi" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sink/directional/east,
@@ -7118,7 +7161,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gbM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -7203,7 +7246,7 @@
 	name = "Interlink Bar Shutters"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gko" = (
 /obj/structure/flora/grass/jungle/a/style_4,
 /turf/open/misc/grass/planet,
@@ -7308,7 +7351,7 @@
 	},
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gsj" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -7321,6 +7364,11 @@
 	},
 /turf/open/lava/fake,
 /area/centcom/holding/cafepark)
+"gsK" = (
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "gsO" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -7422,7 +7470,7 @@
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gBj" = (
 /obj/item/modular_computer/pda/clear,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -7437,7 +7485,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gCQ" = (
 /obj/structure/chair/sofa/corp,
 /obj/effect/turf_decal/stripes/line,
@@ -7446,6 +7494,9 @@
 "gCR" = (
 /turf/closed/wall/mineral/sandstone,
 /area/centcom/holding/cafe)
+"gEB" = (
+/turf/open/floor/carpet/red,
+/area/centcom/interlink/departures)
 "gIO" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -7475,7 +7526,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "gLS" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/steel,
@@ -7665,7 +7716,7 @@
 /area/centcom/holding/cafepark)
 "hcR" = (
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hds" = (
 /obj/structure/table,
 /obj/machinery/light/directional/east,
@@ -7761,7 +7812,7 @@
 	},
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hkT" = (
 /obj/structure/toilet{
 	dir = 8
@@ -7784,7 +7835,7 @@
 "hnz" = (
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hoi" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -7895,7 +7946,7 @@
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hsW" = (
 /obj/structure/chair/sofa/bamboo/right,
 /turf/open/water/hot_spring/cafe,
@@ -7916,7 +7967,7 @@
 "hvy" = (
 /obj/machinery/door/poddoor/shuttledock/interlink,
 /turf/open/floor/plating,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hvL" = (
 /obj/structure/chair/sofa/bamboo,
 /turf/open/water/hot_spring/cafe,
@@ -7960,7 +8011,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hAL" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Interlink Cryogenics"
@@ -8007,7 +8058,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hIH" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -8020,6 +8071,11 @@
 /obj/structure/stone_tile/slab,
 /turf/open/floor/fakebasalt,
 /area/centcom/holding/cafepark)
+"hKj" = (
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "hKI" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -8053,7 +8109,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hOy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/item/kirbyplants/random,
@@ -8107,6 +8163,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding/cafepark)
+"hRw" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/interlink/departures)
 "hRJ" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -8128,6 +8190,14 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/centcom/interlink)
+"hTa" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "hTf" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/iv_drip,
@@ -8149,7 +8219,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hVq" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/siding/wood{
@@ -8178,7 +8248,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "hWY" = (
 /obj/structure/railing{
 	invisibility = 100
@@ -8240,12 +8310,12 @@
 "iax" = (
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ibU" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "icB" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/sofa/left/brown,
@@ -8382,12 +8452,12 @@
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ilq" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "inr" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -8460,7 +8530,7 @@
 "iqO" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iqT" = (
 /obj/structure/flora/grass/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_yw,
@@ -8551,7 +8621,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "izJ" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/asteroid/snow/indestructible/planet,
@@ -8630,11 +8700,11 @@
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iGO" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iGS" = (
 /turf/closed/indestructible/alien,
 /area/centcom/holding/cafepark)
@@ -8671,18 +8741,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iLl" = (
 /obj/effect/turf_decal/trimline/blue/filled/arrow_cw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iMl" = (
 /obj/effect/turf_decal/nova_decals/misc/handicapped,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iMY" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 1
@@ -8728,7 +8798,7 @@
 /obj/structure/hedge,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iTf" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -8737,7 +8807,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iTA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8750,11 +8820,11 @@
 "iUg" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iUm" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iVr" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north,
@@ -8792,7 +8862,7 @@
 /obj/structure/flora/tree/jungle,
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "iXZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8900,7 +8970,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jfl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -8949,7 +9019,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jhR" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/wood,
@@ -8972,7 +9042,7 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jmI" = (
 /obj/item/toy/beach_ball,
 /obj/effect/spawner/liquids_spawner,
@@ -9013,7 +9083,7 @@
 "joE" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jpm" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -9025,7 +9095,7 @@
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jqo" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -9036,6 +9106,10 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"jqB" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/centcom/interlink/departures)
 "jsN" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/delivery,
@@ -9129,7 +9203,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jzh" = (
 /obj/structure/table{
 	name = "Jim Norton's Quebecois Coffee table"
@@ -9208,7 +9282,7 @@
 "jGh" = (
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jGH" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9230,7 +9304,7 @@
 "jHv" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jHw" = (
 /obj/structure/sign/directions/arrival{
 	dir = 1
@@ -9254,14 +9328,20 @@
 	},
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jIj" = (
 /turf/open/floor/wood,
 /area/centcom/holding/cafedorms)
+"jJM" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "jKj" = (
 /obj/structure/bed/pod,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jMh" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 9
@@ -9313,7 +9393,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jSW" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt,
@@ -9343,13 +9423,13 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jUK" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Interlink Medbay"
 	},
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jXq" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -9358,7 +9438,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "jXO" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
@@ -9466,7 +9546,7 @@
 "khz" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "khC" = (
 /obj/machinery/button/door/directional/north{
 	id = "il_kitchen";
@@ -9475,7 +9555,7 @@
 	req_access = list("kitchen")
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kiU" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
@@ -9507,7 +9587,7 @@
 	desc = "Why would you want to go back, you just got here!";
 	name = "Interlink Re-Education Room"
 	},
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kmV" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Interlink Access"
@@ -9521,7 +9601,7 @@
 "knx" = (
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "knL" = (
 /obj/structure/chair/sofa/right/brown,
 /turf/open/floor/wood,
@@ -9539,7 +9619,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kpY" = (
 /obj/structure/closet/cabinet,
 /obj/item/stamp/head/rd{
@@ -9592,6 +9672,13 @@
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/misc/grass/planet,
 /area/centcom/holding/cafepark)
+"kvc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "kvD" = (
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/iron/dark,
@@ -9625,7 +9712,7 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kxO" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -9641,7 +9728,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kDh" = (
 /obj/structure/curtain/cloth/fancy/mechanical{
 	id = "ghostcaferesort2curtain"
@@ -9651,7 +9738,7 @@
 "kDO" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kFE" = (
 /obj/structure/spacevine,
 /obj/structure/fans/tiny/invisible,
@@ -9677,7 +9764,7 @@
 /obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kHZ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/misc/dirt/planet,
@@ -9743,6 +9830,13 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafe)
+"kJC" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "kJL" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_x = 9;
@@ -9809,6 +9903,9 @@
 	desc = "There's been a recent disturbance right here, it's evident something must've been buried; but it's pretty deep. A faint, yet deep humming sound emanates from the spot as you get closer."
 	},
 /area/centcom/holding/cafepark)
+"kMr" = (
+/turf/open/floor/iron/white,
+/area/centcom/interlink/departures)
 "kMw" = (
 /obj/structure/chair/stool/directional/south{
 	dir = 4
@@ -9833,7 +9930,7 @@
 	name = "Interlink Kitchen"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kOf" = (
 /obj/item/food/grown/herbs,
 /obj/item/food/grown/herbs,
@@ -9848,11 +9945,11 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kOk" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kOZ" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
@@ -9886,7 +9983,19 @@
 "kSc" = (
 /obj/item/pickaxe,
 /turf/open/misc/dirt/planet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"kSk" = (
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/medical,
+/obj/structure/sign/directions/arrival{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/interlink/departures)
 "kTe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -9894,7 +10003,7 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kTY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9919,7 +10028,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "kWI" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -10039,6 +10148,13 @@
 "lcR" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/interlink/dorm_rooms)
+"lcU" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "ldK" = (
 /obj/structure/toilet{
 	pixel_y = 12
@@ -10168,7 +10284,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"ljT" = (
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/misc/dirt/planet,
+/area/centcom/interlink/departures)
 "lkn" = (
 /obj/structure/spacevine,
 /turf/open/water/beach,
@@ -10191,7 +10311,7 @@
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lnP" = (
 /obj/structure/sign/poster/contraband/space_cola/directional/north,
 /obj/machinery/vending/boozeomat/cafe,
@@ -10399,7 +10519,7 @@
 "lHT" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lHZ" = (
 /obj/structure/mop_bucket,
 /obj/machinery/duct,
@@ -10470,7 +10590,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lQB" = (
 /obj/structure/bed/double{
 	dir = 8
@@ -10503,7 +10623,7 @@
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lSB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -10537,7 +10657,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/tree/jungle/style_6,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lVs" = (
 /obj/effect/turf_decal/siding{
 	color = "#2e2e2e";
@@ -10564,7 +10684,7 @@
 "lXk" = (
 /obj/item/flashlight/lantern,
 /turf/open/misc/dirt/planet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "lXl" = (
 /obj/structure/wall_torch/spawns_lit/directional/east,
 /turf/open/misc/asteroid/snow/indestructible/planet,
@@ -10604,7 +10724,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"mbN" = (
+/obj/structure/flora/rock/style_random,
+/turf/open/misc/dirt/planet,
+/area/centcom/interlink/departures)
 "mcO" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/machinery/light/warm/directional/north,
@@ -10688,7 +10812,7 @@
 /obj/effect/turf_decal/delivery/blue,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mjA" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 4
@@ -10739,7 +10863,7 @@
 "moG" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mpl" = (
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
@@ -10786,7 +10910,7 @@
 	req_access = list("armory")
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mvU" = (
 /obj/structure/chair/sofa/bamboo/right{
 	dir = 1
@@ -10866,7 +10990,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mxI" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/fake_stairs/wood/directional/north,
@@ -10888,7 +11012,7 @@
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mzs" = (
 /obj/structure/toilet{
 	dir = 8
@@ -11143,7 +11267,7 @@
 /area/centcom/holding/cafepark)
 "mSs" = (
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mSw" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -11165,7 +11289,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "mUC" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -11227,11 +11351,11 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nbB" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nbG" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -11299,7 +11423,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nis" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -11326,7 +11450,7 @@
 "niJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "niQ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game{
@@ -11475,7 +11599,7 @@
 "nqW" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nrl" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -11524,6 +11648,10 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"nAY" = (
+/obj/effect/light_emitter/interlink,
+/turf/open/misc/dirt/planet,
+/area/centcom/interlink/departures)
 "nCY" = (
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/any/double,
@@ -11700,13 +11828,13 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nQF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "nRP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -11792,21 +11920,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oab" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oaD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/turf_decal/nova_decals/misc/handicapped,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oaM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11822,14 +11950,14 @@
 "ocT" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oed" = (
 /obj/structure/table,
 /obj/machinery/processor{
 	pixel_y = 12
 	},
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oei" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/sign/departments/restroom/directional/south,
@@ -11866,7 +11994,7 @@
 /obj/item/storage/box/matches,
 /obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oja" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12012,7 +12140,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ovF" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/light_emitter/interlink,
@@ -12177,6 +12305,9 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/holding/cafe)
+"oBr" = (
+/turf/open/misc/dirt/planet,
+/area/centcom/interlink/departures)
 "oCU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -12185,7 +12316,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oDs" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -12222,13 +12353,13 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oJP" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oKM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -12258,7 +12389,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "oOS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -12547,7 +12678,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pej" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -12600,7 +12731,7 @@
 /obj/machinery/light/warm/directional/east,
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "phk" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -12632,6 +12763,13 @@
 	icon_state = "floor"
 	},
 /area/centcom/holding/cafepark)
+"pkg" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "pkJ" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/fence{
@@ -12804,6 +12942,10 @@
 	},
 /turf/closed/indestructible/fakeglass,
 /area/centcom/holding/cafedorms)
+"pAZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/interlink/departures)
 "pBj" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
@@ -12866,7 +13008,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pFm" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -12887,11 +13029,11 @@
 /obj/structure/sign/departments/security/directional/north,
 /obj/effect/turf_decal/trimline/dark_red/filled/corner,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pFt" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pFM" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/fence/interlink{
@@ -12936,7 +13078,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pHG" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
@@ -12959,7 +13101,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pLq" = (
 /obj/structure/rack/wooden,
 /obj/item/dyespray{
@@ -13057,7 +13199,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pNJ" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/bot,
@@ -13075,7 +13217,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pPH" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/flora/ash/stem_shroom,
@@ -13188,7 +13330,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "pXT" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -13261,7 +13403,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qdd" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
@@ -13316,7 +13458,7 @@
 "qhn" = (
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qiI" = (
 /obj/machinery/light/directional/south,
 /turf/open/misc/grass/planet,
@@ -13329,7 +13471,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qji" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -13374,7 +13516,7 @@
 "qna" = (
 /obj/structure/barricade/wooden,
 /turf/open/misc/dirt/planet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qnA" = (
 /obj/structure/closet/crate,
 /obj/item/storage/box/ingredients/vegetarian,
@@ -13413,7 +13555,7 @@
 	},
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qnH" = (
 /obj/structure/flora/grass/jungle/b/style_2,
 /obj/effect/light_emitter/interlink,
@@ -13494,7 +13636,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qtz" = (
 /obj/structure/hedge/opaque,
 /obj/structure/fans/tiny/invisible,
@@ -13511,11 +13653,11 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qvk" = (
 /obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qwc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13533,7 +13675,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qwo" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/snack,
@@ -13546,7 +13688,7 @@
 /area/centcom/holding/cafe)
 "qyu" = (
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qze" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 5
@@ -13578,7 +13720,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qBd" = (
 /obj/machinery/light/directional/west,
 /turf/open/misc/grass/planet,
@@ -13609,7 +13751,7 @@
 "qEu" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qFt" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -13644,7 +13786,7 @@
 "qHJ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qHT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair/sofa/bench/left{
@@ -13691,13 +13833,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qKi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/stone,
 /area/centcom/holding/cafepark)
+"qKI" = (
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "qLQ" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/dark,
@@ -13737,7 +13884,7 @@
 	name = "Interlink Bar"
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qPy" = (
 /obj/structure/chair/sofa/corp{
 	dir = 8
@@ -13748,7 +13895,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qQv" = (
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe)
@@ -13774,7 +13921,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "qTu" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
@@ -13865,6 +14012,10 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/interlink)
+"raM" = (
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "rbo" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -13872,7 +14023,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rbT" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
@@ -13918,7 +14069,7 @@
 "rjf" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rjg" = (
 /obj/structure/stone_tile/block/cracked,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -14000,7 +14151,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rne" = (
 /obj/item/paper{
 	default_raw_text = "Hello valued Patron! The Cafe has underwent recent renovations! The most noticable additions are a horror themed 'Hive' room in the southeast (please note that due to this theme, there are currently no doors, managment is looking into adding them) and a Sci-Fi 'Alien abduction' theme, just south of the Drobe room. Thank you,\n -The Managment.";
@@ -14097,7 +14248,7 @@
 	greyscale_colors = "#AA8A61"
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rCf" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/siding/blue,
@@ -14155,7 +14306,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rGI" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4;
@@ -14202,7 +14353,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rKT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/left/directional/north{
@@ -14216,7 +14367,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rMF" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
@@ -14227,7 +14378,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rMZ" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -14260,7 +14411,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rNR" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
@@ -14353,7 +14504,7 @@
 "rPJ" = (
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rQF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -14366,7 +14517,7 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rRv" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Blueshield's Office"
@@ -14404,21 +14555,21 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rTx" = (
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rTM" = (
 /obj/effect/turf_decal/siding/white/corner,
 /obj/effect/turf_decal/trimline/blue/filled/arrow_cw{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "rTU" = (
 /obj/structure/sign/painting/large/library{
 	dir = 1
@@ -14636,7 +14787,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "slW" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/turf_decal/siding/wood,
@@ -14693,7 +14844,7 @@
 "soW" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "spb" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -14712,7 +14863,7 @@
 "sqZ" = (
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "srf" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/fakeglass,
@@ -14759,7 +14910,7 @@
 	name = "Interlink Bar"
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "stk" = (
 /obj/effect/landmark/latejoin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -14782,7 +14933,7 @@
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "svm" = (
 /obj/machinery/door/airlock{
 	id_tag = "stall1";
@@ -14810,7 +14961,7 @@
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sys" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/sink/directional/south,
@@ -14840,7 +14991,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sBZ" = (
 /obj/structure/dresser,
 /obj/structure/sign/painting/library{
@@ -14868,7 +15019,7 @@
 "sDJ" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sDY" = (
 /obj/structure/railing,
 /turf/open/indestructible/cobble/corner{
@@ -14975,7 +15126,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sJJ" = (
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/siding/dark{
@@ -14983,13 +15134,13 @@
 	},
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sKg" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sKP" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/robo_wardrobe,
@@ -15044,7 +15195,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sPA" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/item/kirbyplants/random,
@@ -15075,7 +15226,7 @@
 /obj/structure/chair/sofa/bench/right,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sSe" = (
 /obj/structure/stone_tile/center,
 /obj/structure/stone_tile/surrounding_tile{
@@ -15093,14 +15244,14 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sTH" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sUC" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/flora/grass/jungle/a/style_3,
@@ -15174,7 +15325,7 @@
 /obj/item/food/grown/wheat,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "sYV" = (
 /obj/machinery/door/poddoor/ert,
 /turf/closed/indestructible/riveted,
@@ -15249,7 +15400,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "tdp" = (
 /obj/effect/light_emitter/interlink,
 /obj/effect/turf_decal/weather/dirt{
@@ -15300,6 +15451,11 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"tii" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "tik" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -15322,6 +15478,11 @@
 "tky" = (
 /turf/open/indestructible/bathroom,
 /area/centcom/holding/cafe)
+"tkK" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "tlu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15712,7 +15873,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uab" = (
 /obj/machinery/button/door{
 	id = "ghostcafekitchen";
@@ -15824,7 +15985,7 @@
 "ufv" = (
 /obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ufz" = (
 /obj/structure/sign/painting/large/library{
 	dir = 1
@@ -15915,7 +16076,7 @@
 	name = "Breaks-The-Maps"
 	},
 /turf/open/misc/dirt/planet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ujV" = (
 /obj/structure/sign/painting/large/library{
 	dir = 4
@@ -16041,13 +16202,13 @@
 /obj/effect/turf_decal/siding/white,
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uAm" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uAN" = (
 /obj/structure/chair/stool/bamboo,
 /turf/open/floor/fakebasalt,
@@ -16058,6 +16219,9 @@
 /obj/structure/alien/weeds/node,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
+"uCl" = (
+/turf/closed/indestructible/rock,
+/area/centcom/interlink/departures)
 "uCw" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -16073,7 +16237,7 @@
 	},
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uDT" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -16092,7 +16256,7 @@
 /obj/structure/table,
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uET" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -16102,6 +16266,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"uFy" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/light_emitter/interlink,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "uFG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/indestructible{
@@ -16109,7 +16278,7 @@
 	name = "Interlink Kitchen Shutters"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uGt" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -16125,7 +16294,7 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uIf" = (
 /obj/structure/closet,
 /turf/open/floor/iron,
@@ -16147,7 +16316,7 @@
 /obj/machinery/deepfryer,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uJA" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/dice{
@@ -16170,7 +16339,7 @@
 "uKW" = (
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uMR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -16204,7 +16373,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "uTg" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Interlink"
@@ -16258,6 +16427,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/interlink)
+"uWZ" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/centcom/interlink/departures)
 "uXf" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -16328,17 +16501,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vcB" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vdv" = (
 /obj/machinery/light/directional/west,
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vdA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16441,7 +16614,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vqx" = (
 /obj/structure/flora/bush/sparsegrass,
 /obj/structure/flora/bush/reed,
@@ -16533,7 +16706,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vxC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
@@ -16599,11 +16772,11 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vFj" = (
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vFM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -16623,7 +16796,7 @@
 /obj/machinery/light/very_dim/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vIX" = (
 /obj/structure/table,
 /obj/item/soap,
@@ -16634,7 +16807,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vLx" = (
 /turf/closed/indestructible/rock,
 /area/centcom/interlink)
@@ -16664,7 +16837,7 @@
 	name = "Interlink Cafe"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vNe" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/railing/wooden_fencing{
@@ -16695,7 +16868,7 @@
 "vPe" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vQH" = (
 /obj/structure/table/wood,
 /turf/open/misc/dirt/planet,
@@ -16714,7 +16887,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vRE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -16754,7 +16927,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/structure/chair/sofa/bench,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "vWy" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -16826,7 +16999,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wbI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -16919,6 +17092,9 @@
 /obj/effect/light_emitter/interlink,
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe)
+"whR" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/interlink/departures)
 "wiT" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/hedge,
@@ -16927,7 +17103,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wji" = (
 /obj/structure/flora/rock/style_random,
 /turf/open/misc/dirt/planet,
@@ -16940,7 +17116,7 @@
 "wkG" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wkQ" = (
 /obj/structure/railing{
 	invisibility = 100;
@@ -16973,7 +17149,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wnj" = (
 /obj/structure/reagent_water_basin,
 /turf/open/misc/dirt/planet,
@@ -16987,7 +17163,11 @@
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
+"woJ" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "wpz" = (
 /obj/effect/light_emitter/interlink,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -17036,12 +17216,16 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
 /area/centcom/interlink)
+"wuG" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "wuH" = (
 /obj/structure/table,
 /obj/machinery/light/cold/directional/north,
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wvy" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -17087,7 +17271,7 @@
 	pixel_y = 8
 	},
 /turf/closed/indestructible/riveted,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wyL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "ERT Access"
@@ -17105,7 +17289,7 @@
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wAE" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot,
@@ -17126,7 +17310,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_ccw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wBV" = (
 /obj/structure/railing,
 /turf/open/indestructible/cobble/side,
@@ -17176,13 +17360,13 @@
 	},
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wHm" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wHJ" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/warning{
 	dir = 10
@@ -17216,7 +17400,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/cafeteria,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wIA" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -17279,7 +17463,7 @@
 	},
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wOi" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/siding/wood{
@@ -17342,7 +17526,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "wXm" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -17406,7 +17590,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xbn" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/light_emitter/interlink,
@@ -17432,7 +17616,7 @@
 	},
 /obj/effect/turf_decal/delivery/blue,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xec" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle/infinite{
@@ -17449,6 +17633,12 @@
 /obj/structure/closet/crate/wooden/storage_barrel,
 /turf/open/misc/dirt/planet,
 /area/centcom/holding/cafepark)
+"xez" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/light_emitter/interlink,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/centcom/interlink/departures)
 "xfD" = (
 /obj/structure/punching_bag,
 /turf/open/indestructible/hotelwood,
@@ -17588,7 +17778,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xso" = (
 /obj/structure/rack/wooden,
 /obj/effect/turf_decal/siding/wood{
@@ -17654,7 +17844,7 @@
 "xzh" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xzt" = (
 /obj/structure/chair/sofa/bench{
 	dir = 1
@@ -17774,13 +17964,13 @@
 	name = "Interlink Bar"
 	},
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xJz" = (
 /turf/closed/indestructible/fakedoor{
 	desc = "Why would you want to go back, you just got here!";
 	name = "Cent Com Prison Shuttle Dock"
 	},
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xKI" = (
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 1
@@ -17804,7 +17994,7 @@
 "xLS" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xNO" = (
 /obj/structure/chair/sofa/bamboo/left,
 /turf/open/water/hot_spring/cafe,
@@ -17817,14 +18007,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xOQ" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xPx" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -17863,6 +18053,11 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/interlink)
+"xQl" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/centcom/interlink/departures)
 "xQK" = (
 /obj/structure/bed/double,
 /obj/effect/spawner/random/bedsheet/double,
@@ -17909,7 +18104,7 @@
 /obj/item/food/grown/whitebeet,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "xTZ" = (
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -17984,7 +18179,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood/parquet,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "yaL" = (
 /obj/machinery/chem_master/fullupgrade,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -18006,7 +18201,7 @@
 "ybC" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/smooth,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ybQ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/sepia,
@@ -18026,7 +18221,7 @@
 	},
 /obj/effect/light_emitter/interlink,
 /turf/open/floor/grass,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "ycB" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
@@ -18053,6 +18248,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding/cafe)
+"ycP" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/centcom/interlink/departures)
 "yde" = (
 /obj/structure/flora/bush/jungle/a,
 /obj/effect/light_emitter/interlink,
@@ -18080,7 +18279,7 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw,
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "yev" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/red,
@@ -18090,7 +18289,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "yfX" = (
 /obj/effect/landmark/latejoin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -18108,7 +18307,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/freezer,
-/area/centcom/interlink)
+/area/centcom/interlink/departures)
 "yjC" = (
 /obj/effect/turf_decal/weather/snow/corner,
 /obj/structure/rack/wooden,
@@ -23884,14 +24083,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
+whR
+whR
 xJz
-tvw
-tvw
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa
@@ -24146,9 +24345,9 @@ jys
 uAm
 fqg
 dkD
-hvQ
+biH
 rMy
-tvw
+whR
 aaa
 aaa
 aaa
@@ -24402,10 +24601,10 @@ tvw
 khz
 eKr
 fqg
-aDg
-hvQ
+pAZ
+biH
 eYD
-tvw
+whR
 aaa
 aaa
 aaa
@@ -24659,10 +24858,10 @@ tvw
 uKW
 eKr
 ybC
-tvw
-aDg
-aDg
-tvw
+whR
+pAZ
+pAZ
+whR
 aaa
 aaa
 aaa
@@ -24916,21 +25115,21 @@ tvw
 uKW
 eKr
 fqg
-aDg
-hvQ
+pAZ
+biH
 eYD
-tvw
+whR
 aaa
 aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa
@@ -25174,21 +25373,21 @@ sqZ
 eKr
 fqg
 kxy
-hvQ
+biH
 jKj
-tvw
+whR
 aaa
 aaa
 aaa
 aaa
 aaa
-tvw
+whR
 axP
 izj
 bqc
 pOS
-tvw
-tvw
+whR
+whR
 aaa
 aaa
 aaa
@@ -25430,22 +25629,22 @@ tvw
 xOQ
 pNF
 ybC
-tvw
-aDg
-aDg
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
+whR
+pAZ
+pAZ
+whR
+whR
+whR
+whR
+whR
+whR
+whR
 kHP
-iPU
-iPU
-iPU
+gEB
+gEB
+gEB
 wXe
-tvw
+whR
 aaa
 aaa
 aaa
@@ -25688,21 +25887,21 @@ fqg
 fqg
 fqg
 cYb
-xSr
+woJ
 uGU
-tvw
-aWb
+whR
+kMr
 xLS
 gBR
 mSs
 oJP
-tvw
+whR
 dTl
-iPU
+gEB
 ckD
-iPU
+gEB
 ogI
-tvw
+whR
 aaa
 aaa
 aaa
@@ -25945,21 +26144,21 @@ rPJ
 fqg
 fqg
 cYb
-xSr
+woJ
 jUm
-tvw
+whR
 bQZ
 jhu
-tvw
+whR
 jqm
 lla
-tvw
-sci
-iPU
-iPU
-iPU
+whR
+ycP
+gEB
+gEB
+gEB
 wXe
-tvw
+whR
 aaa
 aaa
 aaa
@@ -26202,21 +26401,21 @@ aGq
 mvL
 bTR
 wzZ
-xSr
+woJ
 qQl
-tvw
+whR
 wuH
-hIH
-tvw
-tvw
-tvw
-tvw
+jqB
+whR
+whR
+whR
+whR
 hAk
-tvw
-tvw
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa
@@ -26457,23 +26656,23 @@ spb
 tvw
 ilq
 jjQ
-xSr
+woJ
 qbw
-xSr
-xSr
-tvw
+woJ
+woJ
+whR
 xdQ
-hIH
-tvw
+jqB
+whR
 egG
 wGV
-tvw
-aQY
+whR
+aAM
 eaT
 eaT
 sDJ
-aQY
-tvw
+aAM
+whR
 aaa
 aaa
 aaa
@@ -26713,24 +26912,24 @@ fcW
 ckG
 tvw
 vcB
-xSr
-xSr
+woJ
+woJ
 bCB
-xSr
-xSr
-tvw
+woJ
+woJ
+whR
 mju
 rNI
-tvw
+whR
 dtL
 xaT
-tvw
+whR
 qEu
-aQY
-aQY
-aQY
-aQY
-tvw
+aAM
+aAM
+aAM
+aAM
+whR
 aaa
 aaa
 aaa
@@ -26973,21 +27172,21 @@ tvw
 tvw
 tvw
 tvw
-tvw
+whR
 pFr
-tvw
-aDg
+whR
+pAZ
 mbx
-tvw
+whR
 sSX
-tvw
-tvw
+whR
+whR
 bxj
 sDJ
 jHv
 iGO
 vFj
-tvw
+whR
 aaa
 aaa
 aaa
@@ -27238,13 +27437,13 @@ sTH
 nZP
 pHi
 kzD
-tvw
-aQY
-aQY
-aQY
-aQY
+whR
+aAM
+aAM
+aAM
+aAM
 dDp
-tvw
+whR
 aaa
 aaa
 aaa
@@ -27487,21 +27686,21 @@ aQY
 aQY
 moe
 tvw
-aXG
+cVu
 cuM
-tvw
+whR
 qsQ
-hIH
-aWb
-aWb
+jqB
+kMr
+kMr
 yfm
-tvw
+whR
 fxE
-aQY
-aQY
-aQY
+aAM
+aAM
+aAM
 rAe
-tvw
+whR
 aaa
 aaa
 aaa
@@ -27744,21 +27943,21 @@ cdj
 aQY
 aCK
 tvw
-dLq
+amL
 cuM
-tvw
+whR
 mTS
-hIH
-aWb
-aWb
+jqB
+kMr
+kMr
 yfm
-tvw
+whR
 rQF
-vRE
-vRE
-vRE
+bIC
+bIC
+bIC
 jHB
-tvw
+whR
 aaa
 aaa
 aaa
@@ -28001,21 +28200,21 @@ igp
 igp
 beg
 tvw
-aXG
+cVu
 cuM
-tvw
+whR
 sJJ
 rTv
-oDs
-oDs
+hRw
+hRw
 lSo
-tvw
+whR
 ikG
 iqO
-hvQ
+biH
 cKf
 bae
-tvw
+whR
 aaa
 aaa
 aaa
@@ -28258,21 +28457,21 @@ qIY
 cFK
 fiC
 tvw
-aXG
+cVu
 cuM
-tvw
+whR
 esP
 tZU
-hvQ
-hvQ
+biH
+biH
 cLD
-tvw
+whR
 ikG
 iqO
-hvQ
+biH
 cKf
 bae
-tvw
+whR
 aaa
 aaa
 aaa
@@ -28515,21 +28714,21 @@ nOb
 tvw
 tvw
 gfW
-aXG
+cVu
 cuM
-gfW
-tvw
+kSk
+whR
 eLt
 jUK
-aDg
-aDg
-tvw
-lPi
-lPi
+pAZ
+pAZ
+whR
+uWZ
+uWZ
 sOk
-lPi
-lPi
-tvw
+uWZ
+uWZ
+whR
 aaa
 aaa
 aaa
@@ -28771,21 +28970,21 @@ saE
 saE
 buc
 pDd
-aXG
-aXG
+cVu
+cVu
 cuM
 gAH
 wME
 iLl
-aXG
-aXG
-aXG
+cVu
+cVu
+cVu
 jGh
-aXG
+cVu
 moG
 eFV
 moG
-aXG
+cVu
 hvy
 aaa
 aaa
@@ -29028,8 +29227,8 @@ aXG
 pXn
 aXG
 nAp
-aXG
-aXG
+cVu
+cVu
 cuM
 faN
 qAW
@@ -29286,20 +29485,20 @@ tvw
 tvw
 dFF
 niJ
-aXG
+cVu
 yet
 dAC
-hvQ
-hvQ
+biH
+biH
 jXq
 sRV
-hvQ
-hvQ
+biH
+biH
 sJa
 gKP
 eFV
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -29541,8 +29740,8 @@ bVH
 aTE
 aXG
 pGZ
-pmJ
-aXG
+cXT
+cVu
 ecW
 sBJ
 vLh
@@ -29798,22 +29997,22 @@ bVH
 aTE
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 mzf
 lHT
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
 hWX
 ibU
-hvQ
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
+biH
 eVe
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -30055,22 +30254,22 @@ lOD
 gUi
 qey
 kmV
-wJj
-aXG
+wuG
+cVu
 mzf
 lHT
-hvQ
-hvQ
+biH
+biH
 kOk
 hWX
 ibU
 kOk
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
 eVe
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -30312,8 +30511,8 @@ xEn
 aOl
 qey
 eRc
-wJj
-aXG
+wuG
+cVu
 cBq
 iJX
 pdW
@@ -30326,8 +30525,8 @@ pdW
 pdW
 fWc
 wBI
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -30569,8 +30768,8 @@ aDg
 aOl
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 ecW
 qTa
 iTf
@@ -30583,8 +30782,8 @@ iTf
 iTf
 qjh
 faI
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -30826,22 +31025,22 @@ aDg
 aOl
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 mzf
 lHT
-hvQ
-hvQ
+biH
+biH
 kOk
 hWX
 ibU
 kOk
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
 eVe
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -31083,8 +31282,8 @@ aDg
 aOl
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 mzf
 lHT
 wmW
@@ -31340,22 +31539,22 @@ pTO
 aOl
 qey
 kmV
-wJj
-aXG
+wuG
+cVu
 cBq
 rTx
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
 hWX
 vUJ
-hvQ
-hvQ
-hvQ
+biH
+biH
+biH
 oJo
 wBI
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -31597,8 +31796,8 @@ lOD
 gUi
 qey
 eRc
-wJj
-aXG
+wuG
+cVu
 rjf
 brL
 jRW
@@ -31854,10 +32053,10 @@ bVH
 aTE
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 rjf
-aXG
+cVu
 rFa
 cIk
 cIk
@@ -31866,10 +32065,10 @@ rFa
 cIk
 cIk
 hVf
-aXG
+cVu
 rjf
-aXG
-aXG
+cVu
+cVu
 hvy
 aaa
 aaa
@@ -32111,23 +32310,23 @@ bVH
 aTE
 aXG
 pGZ
-aXG
-aXG
+cVu
+cVu
 rjf
 sKg
 sKg
 sKg
 rMY
 sKg
-aXG
+cVu
 qhn
-aXG
-aXG
-aXG
+cVu
+cVu
+cVu
 rjf
-aXG
-aXG
-tvw
+cVu
+cVu
+whR
 aaa
 aaa
 aaa
@@ -32368,23 +32567,23 @@ tvw
 tvw
 tvw
 tvw
-lPi
-lPi
+uWZ
+uWZ
 drE
 qPw
-lPi
-lPi
+uWZ
+uWZ
 wyF
 vGe
 ufv
 wyF
-lPi
-lPi
+uWZ
+uWZ
 qyu
 vLY
-lPi
-lPi
-tvw
+uWZ
+uWZ
+whR
 aaa
 aaa
 aaa
@@ -32631,17 +32830,17 @@ hcR
 hcR
 csC
 uDr
-tvw
+whR
 rjf
-aXG
-tvw
+cVu
+whR
 nbv
 oOM
 qyu
 qyu
 slz
 pXu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -32879,7 +33078,7 @@ iPs
 dfL
 tvw
 vpT
-aXG
+cVu
 iax
 gjK
 hkQ
@@ -32888,17 +33087,17 @@ hcR
 hcR
 nqW
 xZN
-tvw
+whR
 rjf
-gAj
-tvw
+ceI
+whR
 joE
 esD
 qyu
 qyu
 esD
 bUg
-tvw
+whR
 aaa
 aaa
 aaa
@@ -33147,7 +33346,7 @@ hcR
 hcR
 xIR
 rjf
-aXG
+cVu
 dXN
 qyu
 qyu
@@ -33155,7 +33354,7 @@ vPe
 vPe
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -33393,7 +33592,7 @@ tpU
 sgD
 tvw
 mxj
-aXG
+cVu
 iax
 gjK
 hkQ
@@ -33404,7 +33603,7 @@ hcR
 hcR
 eTo
 rjf
-aXG
+cVu
 qyu
 qyu
 qyu
@@ -33412,7 +33611,7 @@ esD
 esD
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -33659,17 +33858,17 @@ hcR
 hcR
 nqW
 wHm
-tvw
+whR
 wod
-aXG
-tvw
+cVu
+whR
 qyu
 qyu
 kDO
 kDO
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -33908,7 +34107,7 @@ heB
 tvw
 tvw
 iUg
-aXG
+cVu
 std
 phc
 nQF
@@ -33916,17 +34115,17 @@ nQF
 nQF
 bul
 gsc
-tvw
+whR
 rjf
-aXG
-tvw
+cVu
+whR
 cBR
 hNU
 qyu
 qyu
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -34164,26 +34363,26 @@ tpU
 dfL
 vat
 tvw
-tvw
-tvw
-tvw
-tvw
-xyz
-wAE
-enb
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
+tii
+xQl
+tkK
+whR
+whR
+whR
 hsr
 vRf
-tvw
+whR
 vEI
 iMl
 vPe
 vPe
 vPe
 nbB
-tvw
+whR
 aaa
 aaa
 aaa
@@ -34421,26 +34620,26 @@ tpU
 dxP
 rVQ
 hbE
-vat
-wpz
-vat
-tvw
-lPi
-lPi
-lPi
-tvw
-vat
-dVb
-iPs
-iPs
+raM
+qKI
+raM
+whR
+uWZ
+uWZ
+uWZ
+whR
+raM
+uFy
+nAY
+nAY
 fHl
-tvw
+whR
 uFG
 uFG
 uFG
 uFG
 kNd
-tvw
+whR
 aaa
 aaa
 aaa
@@ -34678,26 +34877,26 @@ tpU
 dfL
 fJQ
 hbE
-vat
+raM
 syc
-vat
-vat
-vat
-vat
-vat
-vat
-wpz
-dVb
-iPs
-iPs
-dfL
-tvw
+raM
+raM
+raM
+raM
+raM
+raM
+qKI
+uFy
+nAY
+nAY
+eoj
+whR
 khC
 qyu
 qyu
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -34935,26 +35134,26 @@ tpU
 sgD
 vat
 hbE
-vat
-vat
-iuK
-iuK
-vat
-vat
-vat
-vat
+raM
+raM
+eeA
+eeA
+raM
+raM
+raM
+raM
 dky
-dVb
-iPs
-iPs
-dfL
-tvw
+uFy
+nAY
+nAY
+eoj
+whR
 qHJ
 rbo
 wIg
 qyu
 qyu
-tvw
+whR
 aaa
 aaa
 aaa
@@ -35192,26 +35391,26 @@ tpU
 dfL
 vat
 hbE
-vat
+raM
 iXq
-iuK
-iuK
-rSa
-vat
-vat
-vat
-rVQ
-fIY
-iPs
-iPs
-dfL
-lPi
+eeA
+eeA
+hKj
+raM
+raM
+raM
+bRX
+xez
+nAY
+nAY
+eoj
+uWZ
 qyu
 qyu
 uIp
 iUm
 qvk
-tvw
+whR
 aaa
 aaa
 aaa
@@ -35449,26 +35648,26 @@ tpU
 dfL
 vat
 hbE
-vat
-vat
-iuK
-iuK
-vat
-vat
-vat
-fJQ
-vat
-dVb
-iPs
-iPs
-sgD
-lPi
+raM
+raM
+eeA
+eeA
+raM
+raM
+raM
+gsK
+raM
+uFy
+nAY
+nAY
+hTa
+uWZ
 cBR
 rKs
-tvw
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa
@@ -35706,26 +35905,26 @@ tpU
 sgD
 fJQ
 hbE
-vat
-fJQ
-rVQ
-vat
+raM
+gsK
+bRX
+raM
 cfu
 cfu
 cfu
 xzh
 cfu
-dVb
-iPs
-iPs
-dfL
-tvw
+uFy
+nAY
+nAY
+eoj
+whR
 pFe
-tvw
-tvw
+whR
+whR
 soW
 oed
-tvw
+whR
 aaa
 aaa
 aaa
@@ -35963,26 +36162,26 @@ iPs
 dfL
 rSa
 hbE
-rSa
-vat
-vat
-vat
+hKj
+raM
+raM
+raM
 pFt
 eRB
 cfu
 cfu
 cfu
-xtQ
-iPs
-iPs
-dfL
-tvw
+jJM
+nAY
+nAY
+eoj
+whR
 mSs
 mSs
 mSs
 mSs
 uEn
-tvw
+whR
 aaa
 aaa
 aaa
@@ -36220,26 +36419,26 @@ iPs
 dfL
 vat
 hbE
-vat
-vat
-vat
-vat
+raM
+raM
+raM
+raM
 qub
 qub
 cfu
 knx
 dbZ
-pYF
-iPs
-iPs
+lcU
+nAY
+nAY
 oCU
-tvw
+whR
 hnz
 mSs
 mSs
 mSs
 fHA
-tvw
+whR
 aaa
 aaa
 aaa
@@ -36477,26 +36676,26 @@ eAA
 tvw
 tvw
 tvw
-vat
-vat
-vat
-dVb
-tpU
-tpU
+raM
+raM
+raM
+uFy
+oBr
+oBr
 iFY
 cHY
-tpU
-iPs
-iPs
-iPs
-dfL
-tvw
+oBr
+nAY
+nAY
+nAY
+eoj
+whR
 sYC
 xTC
 kOf
 mSs
 ygL
-tvw
+whR
 aaa
 aaa
 aaa
@@ -36734,26 +36933,26 @@ aqG
 aqG
 aqG
 tvw
-vat
-rVQ
-fJQ
-vat
+raM
+bRX
+gsK
+raM
 suL
 aKa
-tpU
-tpU
-tpU
-iPs
-iPs
-iPs
-dfL
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
+oBr
+oBr
+oBr
+nAY
+nAY
+nAY
+eoj
+whR
+whR
+whR
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa
@@ -36991,26 +37190,26 @@ aqG
 aqG
 aqG
 tvw
-vat
-vat
-vat
-vat
-vat
-vat
-nKJ
-nKJ
-nKJ
-jtf
-iPs
+raM
+raM
+raM
+raM
+raM
+raM
+pkg
+pkg
+pkg
+kvc
+nAY
 nQm
-fJQ
-vLx
-vLx
-vLx
-vLx
-vLx
-vLx
-tvw
+gsK
+uCl
+uCl
+uCl
+uCl
+uCl
+uCl
+whR
 aaa
 aaa
 aaa
@@ -37248,26 +37447,26 @@ aqG
 aqG
 aqG
 tvw
-vat
-vat
-vat
+raM
+raM
+raM
 lTP
-vat
-vat
-vat
-vat
-rVQ
-vat
+raM
+raM
+raM
+raM
+bRX
+raM
 ybX
-iPs
+nAY
 wiT
-tpU
-wji
-tpU
-tpU
-tpU
-vLx
-tvw
+oBr
+mbN
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -37505,26 +37704,26 @@ aqG
 aqG
 aqG
 tvw
-vat
-vat
-vat
-vat
-vat
-rSa
-vat
-vat
-fJQ
-dVb
-iPs
-qot
+raM
+raM
+raM
+raM
+raM
+hKj
+raM
+raM
+gsK
+uFy
+nAY
+kJC
 iRz
-tpU
-tpU
-tpU
-tpU
-unt
-vLx
-tvw
+oBr
+oBr
+oBr
+oBr
+ljT
+uCl
+whR
 aaa
 aaa
 aaa
@@ -37762,26 +37961,26 @@ ouF
 aqG
 aqG
 tvw
-vat
-vat
-vat
-vat
-vat
-vat
-vat
-rVQ
-vat
+raM
+raM
+raM
+raM
+raM
+raM
+raM
+bRX
+raM
 syc
-nKJ
-fJQ
+pkg
+gsK
 cQq
-tpU
-tpU
-tpU
-tpU
-tpU
-vLx
-tvw
+oBr
+oBr
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -38019,26 +38218,26 @@ aqG
 aqG
 aqG
 tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-vLx
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+whR
+uCl
 lXk
-tpU
-tpU
-tpU
-vLx
-tvw
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -38288,14 +38487,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-tpU
-tpU
-tpU
-vLx
-tvw
+whR
+uCl
+oBr
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -38545,14 +38744,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-tpU
-unt
-tpU
-vLx
-tvw
+whR
+uCl
+oBr
+oBr
+ljT
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -38802,14 +39001,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-vLx
-tpU
-tpU
-tpU
-vLx
-tvw
+whR
+uCl
+uCl
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -39059,14 +39258,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-vLx
-vLx
-tpU
-tpU
-vLx
-tvw
+whR
+whR
+uCl
+uCl
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -39317,13 +39516,13 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-vLx
-tpU
-tpU
-vLx
-tvw
+whR
+whR
+uCl
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -39575,12 +39774,12 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
+whR
+uCl
 qna
 qna
-vLx
-tvw
+uCl
+whR
 aaa
 aaa
 aaa
@@ -39832,12 +40031,12 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-tpU
-vLx
-tvw
+whR
+uCl
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -40089,12 +40288,12 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-tpU
-vLx
-tvw
+whR
+uCl
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -40345,13 +40544,13 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-vLx
+whR
+whR
+uCl
 qna
 qna
-vLx
-tvw
+uCl
+whR
 aaa
 aaa
 aaa
@@ -40601,14 +40800,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-vLx
-vLx
-tpU
-tpU
-vLx
-tvw
+whR
+whR
+uCl
+uCl
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -40858,14 +41057,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-vLx
-tpU
+whR
+uCl
+uCl
+oBr
 lXk
-tpU
-vLx
-tvw
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -41115,14 +41314,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-wji
-tpU
-tpU
-vLx
-tvw
+whR
+uCl
+oBr
+mbN
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -41372,14 +41571,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
+whR
+uCl
 kSc
-tpU
-tpU
-tpU
-vLx
-tvw
+oBr
+oBr
+oBr
+uCl
+whR
 aaa
 aaa
 aaa
@@ -41629,14 +41828,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
-tpU
-tpU
+whR
+uCl
+oBr
+oBr
+oBr
 evd
-vLx
-tvw
+uCl
+whR
 aaa
 aaa
 aaa
@@ -41886,14 +42085,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-tpU
+whR
+uCl
+oBr
 ujQ
-tpU
-vLx
-vLx
-tvw
+oBr
+uCl
+uCl
+whR
 aaa
 aaa
 aaa
@@ -42143,14 +42342,14 @@ aaa
 aaa
 aaa
 aaa
-tvw
-vLx
-vLx
-vLx
-vLx
-vLx
-tvw
-tvw
+whR
+uCl
+uCl
+uCl
+uCl
+uCl
+whR
+whR
 aaa
 aaa
 aaa
@@ -42400,13 +42599,13 @@ aaa
 aaa
 aaa
 aaa
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
-tvw
+whR
+whR
+whR
+whR
+whR
+whR
+whR
 aaa
 aaa
 aaa

--- a/code/datums/components/sisyphus_awarder.dm
+++ b/code/datums/components/sisyphus_awarder.dm
@@ -46,7 +46,8 @@
 	if (atom_parent.loc != chosen_one)
 		qdel(src) // Hey! How did you do that?
 		return
-	if (entered_area.type != /area/centcom/central_command_areas/evacuation)
+//	if (entered_area.type != /area/centcom/central_command_areas/evacuation) // IRIS EDIT OLD
+	if(!istype(entered_area, /area/centcom/interlink/departures)) // IRIS EDIT NEW (also by the way pods dont come to the interlink)
 		return // Don't istype because taking pods doesn't count
 
 	chosen_one.client?.give_award(/datum/award/achievement/misc/sisyphus, chosen_one)

--- a/modular_iris/code/game/area/areas/centcom.dm
+++ b/modular_iris/code/game/area/areas/centcom.dm
@@ -1,0 +1,2 @@
+/area/centcom/interlink/departures
+	name = "The Interlink Departures"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6655,6 +6655,7 @@
 #include "interface\fonts\vcr_osd_mono.dm"
 #include "modular_iris\code\__DEFINES\ntsl.dm"
 #include "modular_iris\code\__DEFINES\send2relay.dm"
+#include "modular_iris\code\game\area\areas\centcom.dm"
 #include "modular_iris\code\game\objects\items\circuitboards\machine_circuitboards.dm"
 #include "modular_iris\code\game\objects\items\storage\boxes.dm"
 #include "modular_iris\code\modules\blooper\atoms_movable.dm"


### PR DESCRIPTION

## About The Pull Request

Makes the sisyphus achievement actually obtainable via making a new area that encompasses the entirety of the post-shift interlink area (not the middle sections or the walls that touch the departures area

## Why it's Good for the Game

Because sisyphus is NEEDED for the station to function, mining is basically unplayable without him

## Proof of Testing

Tested locally, github is bullying me about the short video i recorded being more than 10MB so look at da code

## Changelog

:cl:
fix: the sisyphus achievement is once again obtainable (don't try to cheat)
/:cl:
