### PR TITLE
Makes automatic code checking work for the modular_iris folder

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -223,6 +223,7 @@ export const DmTarget = new Juke.Target({
     'interface/**',
     'sound/**',
     'modular_nova/**', ///NOVA EDIT ADDITION - Making the CBT work
+    'modular_iris/**', /// IRIS ADDITION
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],


### PR DESCRIPTION

## About The Pull Request

What it says on the title
Basically when you make a change in the modular_iris folder it should recompile the code, but that one line is missing. For some reason.

## Why it's Good for the Game

Makes coding a bit faster, and a lot less painfull

## Proof of Testing

None (it dosen't really say what causes the DM to recompile in the VScode console)

## Changelog

:cl:
code: Added code checking for the modular_iris folder
/:cl:
