### PR TITLE
Redoes DS2-piping to be more accessible and less painful

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -1665,7 +1665,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/meter,
+/obj/machinery/meter{
+	target_layer = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/des_two.dmm
@@ -226,10 +226,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/nova/des_two/security)
 "aZ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 5
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "bd" = (
@@ -993,10 +990,7 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/nova/des_two/service/lounge)
 "em" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
-	dir = 10
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "ep" = (
@@ -1176,7 +1170,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/purple/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -1671,6 +1665,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -3206,24 +3201,24 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,
-/obj/machinery/meter,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "nN" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "nO" = (
@@ -3266,6 +3261,7 @@
 /area/ruin/space/has_grav/nova/des_two/research/robotics)
 "od" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "of" = (
@@ -3295,10 +3291,10 @@
 /turf/open/floor/iron/half,
 /area/ruin/space/has_grav/nova/des_two/research/robotics)
 "oi" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden{
+	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "ok" = (
@@ -4523,10 +4519,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden,
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "tP" = (
@@ -5628,7 +5621,9 @@
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "zy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 9;
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/machinery/light/warm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -6784,8 +6779,8 @@
 /area/ruin/space/has_grav/nova/des_two/security/prison)
 "Fc" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/layer_manifold/purple/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
@@ -9408,8 +9403,15 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	piping_layer = 4;
+	dir = 4;
+	node1_concentration = 0.21;
+	node2_concentration = 0.79;
+	target_pressure = 101
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
@@ -9741,8 +9743,8 @@
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "Si" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/layer_manifold/orange{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
@@ -10102,7 +10104,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/item/stack/sheet/iron/five,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/nova/des_two/engineering)
 "Ty" = (
@@ -12303,7 +12304,7 @@ Tt
 Tt
 Tt
 oi
-aZ
+Jz
 Tt
 Fc
 Jz
@@ -12468,7 +12469,7 @@ Tt
 SI
 rb
 hn
-uD
+aZ
 uD
 od
 iS


### PR DESCRIPTION


## About The Pull Request

Brings DS2 atmos up to standard with the addition of LAYERS. their gas chambers now come equipped with layer adapters for modularity, while their air mixer has been adjusted to be entirely piped on layer 4. Additionally, replaces a spare bunch of metal sheets with a full fledged, albiet empty, canister.

## Why it's Good for the Game

With the recent addition of cargo operations, Ds2 has now become capable of establishing and operating a fully functional atmospherics workshop, cramped as it may be. As a celebration and encouragement to atmos junkies everywhere to join the ghost role, it is now far easier to set up piping for more exotic gas mixtures with all three miners
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
![Testcomplete](https://github.com/user-attachments/assets/abe3f5e7-a961-402e-ad80-de4c14a025a0)

</details>

:cl:
map: The Syndicate has brought DS-2's atmospheric piping up to universal standard, with layer adapters from their storage for ease of piping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
