### PR TITLE
Makes the legion megafauna's crates non-dense until moved

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -168,7 +168,8 @@
 		loot = list(/obj/item/storm_staff)
 		elimination = FALSE
 	else if(prob(20)) //20% chance for sick lootz.
-		loot = list(/obj/structure/closet/crate/necropolis/tendril)
+//		loot = list(/obj/structure/closet/crate/necropolis/tendril) // IRIS EDIT OLD
+		loot = list(/obj/structure/closet/crate/necropolis/tendril/legion) // IRIS EDIT NEW
 		if(!true_spawn)
 			loot = null
 	return ..()

--- a/modular_iris/code/modules/mining/mining_loot.dm
+++ b/modular_iris/code/modules/mining/mining_loot.dm
@@ -1,0 +1,23 @@
+// The legion has a nasty habit of destroying its own chests, so these ones are non-dense until moved
+/obj/structure/closet/crate/necropolis/tendril/legion
+	name = "transparent necropolis chest"
+	desc = "It's watching you suspiciously. You need a skeleton key to open it. Looks you can move through it."
+	density = FALSE
+	alpha = 150
+
+/obj/structure/closet/crate/necropolis/tendril/legion/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/obj/structure/closet/crate/necropolis/tendril/legion/Destroy(force)
+	if(!density)
+		UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	return ..()
+
+/obj/structure/closet/crate/necropolis/tendril/legion/proc/on_moved()
+	SIGNAL_HANDLER
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	name = "necropolis chest"
+	desc = "It's watching you suspiciously. You need a skeleton key to open it."
+	density = TRUE
+	animate(src, time = 3 SECONDS, alpha = 255)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6681,6 +6681,7 @@
 #include "modular_iris\code\modules\blooper\bark.dm"
 #include "modular_iris\code\modules\blooper\bark_list.dm"
 #include "modular_iris\code\modules\limbgrowncorpses\limbgrowerblanks.dm"
+#include "modular_iris\code\modules\mining\mining_loot.dm"
 #include "modular_iris\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "modular_iris\code\modules\reagents\reagent_containers\pill.dm"
 #include "modular_iris\maps\biodome\area.dm"


### PR DESCRIPTION

## About The Pull Request

As the title says, makes the crates legion drops non-dense until they are moved

## Why it's Good for the Game

Because this is one of 2 loot items the legion drops, it in fact very often destroys them turning them into literally sheets of metal

## Changelog

:cl:
fix: The legion megafauna now drops non-dense necropolis chests until you touch them, to avoid the legion breaking them
/:cl:
