### PR TITLE
Makes nabber eyes organic

### DIFF
--- a/modular_iris/monke_ports/gas/code/_nabbers.dm
+++ b/modular_iris/monke_ports/gas/code/_nabbers.dm
@@ -48,7 +48,7 @@
 	species_cookie = /obj/item/food/meat/slab
 	exotic_bloodtype = "H"
 	mutantbrain = /obj/item/organ/brain/nabber
-	mutanteyes = /obj/item/organ/eyes/robotic/nabber
+	mutanteyes = /obj/item/organ/eyes/nabber
 	mutantlungs = /obj/item/organ/lungs/nabber
 	mutantheart = /obj/item/organ/heart/nabber
 	mutantliver = /obj/item/organ/liver/nabber

--- a/modular_iris/monke_ports/gas/code/abilities/nabber_welding_eyes.dm
+++ b/modular_iris/monke_ports/gas/code/abilities/nabber_welding_eyes.dm
@@ -2,7 +2,7 @@
 	name = "Toggle welding shield"
 	desc = "Toggle your eyes welding shield"
 
-	var/obj/item/organ/eyes/robotic/nabber/eyes
+	var/obj/item/organ/eyes/nabber/eyes
 	cooldown_time = 1 SECONDS
 
 /datum/action/cooldown/toggle_welding/Activate()

--- a/modular_iris/monke_ports/gas/code/nabber_organs.dm
+++ b/modular_iris/monke_ports/gas/code/nabber_organs.dm
@@ -32,13 +32,6 @@
 
 /obj/item/organ/eyes/nabber
 	name = "nictating eyes"
-	desc = "Small orange orbs."
-	icon = ORGAN_ICON_NABBER
-	icon_state = "eyes"
-	//flash_protect = FLASH_PROTECTION_SENSITIVE
-
-/obj/item/organ/eyes/robotic/nabber
-	name = "nictating eyes"
 	desc = "Small orange orbs. With pair welding shield linses."
 	icon = ORGAN_ICON_NABBER
 	icon_state = "eyes"
@@ -46,7 +39,7 @@
 	var/datum/action/cooldown/toggle_welding/shield
 	var/active = FALSE
 
-/obj/item/organ/eyes/robotic/nabber/on_mob_insert(mob/living/carbon/eye_recipient)
+/obj/item/organ/eyes/nabber/on_mob_insert(mob/living/carbon/eye_recipient)
 	. = ..()
 	shield = new(eye_recipient)
 	shield.button_icon = 'modular_iris/monke_ports/gas/icons/actions.dmi'
@@ -54,7 +47,7 @@
 	shield.Grant(eye_recipient)
 	shield.eyes = src
 
-/obj/item/organ/eyes/robotic/nabber/proc/toggle_shielding()
+/obj/item/organ/eyes/nabber/proc/toggle_shielding()
 	if(!owner)
 		return
 
@@ -77,7 +70,7 @@
 	shield.button_icon_state = "nabber-shield-0"
 	owner.update_action_buttons()
 
-/obj/item/organ/eyes/robotic/nabber/Remove(mob/living/carbon/eye_owner, special)
+/obj/item/organ/eyes/nabber/Remove(mob/living/carbon/eye_owner, special)
 	. = ..()
 	QDEL_NULL(shield)
 	active = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some reason they were robotic, no comments in code about it and organic ones seem to work the same.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Just makes them fully organic, nothing else.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

tested organic eyes, no abnormalities found

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: made nabber eyes organic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
