### PR TITLE
Fixes helpfull wisps breaking when subjected to shuttle movement code

### DIFF
--- a/modular_iris/code/modules/mining/mining_loot.dm
+++ b/modular_iris/code/modules/mining/mining_loot.dm
@@ -21,3 +21,33 @@
 	desc = "It's watching you suspiciously. You need a skeleton key to open it."
 	density = TRUE
 	animate(src, time = 3 SECONDS, alpha = 255)
+
+/obj/effect/wisp
+	var/mob/last_owner = null
+
+/obj/effect/wisp/Destroy()
+	if(last_owner)
+		UnregisterSignal(last_owner, COMSIG_QDELETING)
+		last_owner = null
+
+	return ..()
+
+/obj/effect/wisp/orbit(atom/A, radius = 10, clockwise = FALSE, rotation_speed = 20, rotation_segments = 36, pre_rotation = TRUE)
+	. = ..()
+	if(!.)
+		return
+
+	if(last_owner)
+		UnregisterSignal(last_owner, COMSIG_QDELETING)
+
+	last_owner = orbit_target
+	RegisterSignal(last_owner, COMSIG_QDELETING, PROC_REF(they_be_goned))
+
+/obj/effect/wisp/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
+	. = ..()
+	if(!orbit_target && last_owner && isturf(loc))
+		orbit(last_owner, 20)
+
+/obj/effect/wisp/proc/they_be_goned()
+	SIGNAL_HANDLER
+	last_owner = null


### PR DESCRIPTION
## About The Pull Request

Without dis PR: When a shuttles moves with you in it, it makes the wisps orbit the turf you are on, slightly displaced to the left
With dis PR: It leaves you, but then immediatelly re-attaches. The only indication of this is the "your vision fades, your vision is enhanced" chat messages yet dis is fully modular so we'll suffer through it

## Why it's Good for the Game

Its annoying to keep resetting them, especially when you are like me and make them all orbit you equally (might become its own future PR tbh for them to equalize)

## Proof of Testing

My words, my shitcode and the fact that the first time i tried i forgot to make a check if we are already orbitting someone (got it on the second server try)

</details>

## Changelog

:cl:
fix: Helpfull wisps from the lanterns inside of necropolis chests no longer leave you for the amazing floor after you fly a shuttle
/:cl:
