### PR TITLE
Black Market Uplink Crafting Rebalance

### DIFF
--- a/code/modules/cargo/markets/market_uplink.dm
+++ b/code/modules/cargo/markets/market_uplink.dm
@@ -161,13 +161,14 @@
 /obj/item/market_uplink/blackmarket/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_CONTRABAND, INNATE_TRAIT)
-
+// IRIS EDIT: Reimplements /obj/item/stock_parts/subspace/amplifier as a requirement for uplink construction
 /datum/crafting_recipe/blackmarket_uplink
 	name = "Black Market Uplink"
 	result = /obj/item/market_uplink/blackmarket
 	time = 30
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_MULTITOOL)
 	reqs = list(
+		/obj/item/stock_parts/subspace/amplifier = 1,
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/assembly/signaler = 1,
 		/obj/item/stack/cable_coil = 15,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Black Market Uplink now requires a Subspace Amplifier to craft, bringing it in line with its old recipe. 
PR'd on behalf of Typebar.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Tl;dr from the discord discussion: We have a quirk that gives you a free Black Market Uplink at the cost of putting you on a watchlist. It's kind of silly, then, that you can craft an uplink using parts from an unhacked autolathe. Everything used in its construction can be obtained both legally and very easily. 

The Subspace Amplifier actually used to be a requirement for crafting the BMU, but was removed to make it more easily accessible in-game as it was never popping up on a round to round basis. Since we now have a quirk that gives you a BMU at roundstart, we can justify making the crafting recipe a little harder to legally obtain. 

<details>
<summary>Also, it's been on the sprite this whole time!</summary>

![She's been with us all along  wait is that fucking-](https://github.com/user-attachments/assets/ffa64af2-7d8d-45b5-839a-111d2aaf2eda)

</details>

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/bc2512c1-b1f7-4fe5-8422-cc1d09e16dc4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Due to shifting orbits, black market uplinks now require a subspace amplifier in their construction to have their signal properly received by the local black market relay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
