### PR TITLE
blake's amazing stowaway fix that shifts a line and adds an indent

### DIFF
--- a/modular_iris/modules/quirks/stowaway.dm
+++ b/modular_iris/modules/quirks/stowaway.dm
@@ -9,7 +9,6 @@
 
 /datum/quirk/stowaway/add_unique()
 	var/mob/living/carbon/human/stowaway = quirk_holder
-	stowaway.Sleeping(5 SECONDS)
 	var/obj/item/card/id/trashed = stowaway.get_item_by_slot(ITEM_SLOT_ID) //No ID
 	qdel(trashed)
 
@@ -22,6 +21,7 @@
 	var/obj/structure/closet/selected_closet = get_unlocked_closed_locker() //Find your new home
 	if(selected_closet)
 		stowaway.forceMove(selected_closet) //Move in
+		stowaway.Sleeping(5 SECONDS)
 
 
 /datum/quirk/stowaway/post_add()


### PR DESCRIPTION
## About The Pull Request

Deals with stowaways dropping items in their hand at the normal spawnpoint by making the sleeping get inflicted after moving the player

## Why it's Good for the Game

this was done on monke where it was ported from, but not here

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
![dreamseeker_VZSnlERIn2](https://github.com/user-attachments/assets/7d154e20-98ba-444b-bf1b-a9aadd61d367)

</details>

## Changelog

:cl:
fix: Stowaways now don't drop their in-hand items at the interlink
/:cl: