### PR TITLE
Expands CentCom Armory

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -129,6 +129,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"aI" = (
+/obj/structure/closet/secure_closet/ert_med,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/sign/departments/medbay/alt/directional/west,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "aK" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
@@ -310,6 +318,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"bq" = (
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "bx" = (
 /turf/open/floor/iron/goonplaque{
 	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
@@ -1180,6 +1208,15 @@
 "fj" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack/gunrack,
+/obj/item/gun/energy/modular_laser_rifle{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/item/gun/energy/modular_laser_rifle{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
 "fk" = (
@@ -1222,6 +1259,25 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"fD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/item/restraints/legcuffs/bola/energy{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/restraints/legcuffs/bola/energy{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/restraints/legcuffs/bola/energy{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "fE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -2289,6 +2345,11 @@
 "km" = (
 /turf/open/floor/carpet/grimey,
 /area/centcom/central_command_areas/control)
+"kn" = (
+/obj/vehicle/sealed/mecha/durand,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/circuit/green,
+/area/centcom/central_command_areas/armory)
 "kq" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -5104,6 +5165,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"wS" = (
+/obj/structure/closet/secure_closet/ert_sec,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "wT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -5508,12 +5577,9 @@
 /turf/open/floor/carpet/grimey,
 /area/centcom/central_command_areas/briefing)
 "yS" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/emps,
-/obj/item/gun/energy/ionrifle,
-/obj/structure/sign/departments/medbay/alt/directional/south,
+/obj/structure/closet/secure_closet/ert_sec,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
@@ -6288,6 +6354,13 @@
 "BR" = (
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"BS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/indestructible{
+	id = "XCCertmech"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "BT" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -6372,6 +6445,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
+"Cu" = (
+/obj/structure/sign/directions/security/directional/west{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/armory)
 "Cx" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
@@ -6565,13 +6645,36 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Dq" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/advanced/s12gauge/rubber{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/item/ammo_box/advanced/s12gauge/rubber{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/ammo_box/advanced/s12gauge/bean{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/ammo_box/advanced/s12gauge/bean{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/advanced/s12gauge/buckshot{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/item/ammo_box/advanced/s12gauge/buckshot{
+	pixel_x = -9;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/area/centcom/central_command_areas/armory)
 "Ds" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -6978,14 +7081,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "FB" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/obj/item/gun/syringe/rapidsyringe,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/armory)
 "FI" = (
 /obj/effect/landmark/thunderdome/two,
@@ -7232,14 +7329,19 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "Hm" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/ferny/style_random,
-/turf/open/floor/iron{
-	icon_state = "asteroid5";
-	name = "plating"
+/obj/item/stock_parts/capacitor/quadratic,
+/obj/item/stock_parts/servo/femto,
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/item/stock_parts/power_store/cell/bluespace,
+/obj/structure/closet/generic/wall/empty{
+	pixel_x = -29;
+	pixel_y = 0
 	},
-/area/centcom/tdome/observation)
+/obj/item/screwdriver,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/armory)
 "Ho" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -7343,6 +7445,10 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
+"HW" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/circuit/green,
+/area/centcom/central_command_areas/armory)
 "HY" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/door/indestructible{
@@ -7484,14 +7590,6 @@
 	name = "CentCom Cell"
 	},
 /area/centcom/central_command_areas/prison/cells)
-"IK" = (
-/obj/structure/closet/secure_closet/ert_sec,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/armory)
 "IO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/floor,
@@ -7533,6 +7631,13 @@
 	},
 /turf/open/floor/circuit/green,
 /area/centcom/tdome/arena)
+"Ju" = (
+/obj/structure/sign/directions/medical/directional/east{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/armory)
 "JC" = (
 /obj/machinery/modular_computer/preset/command{
 	dir = 8
@@ -8485,11 +8590,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "Oz" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/control)
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/circuit/green,
+/area/centcom/central_command_areas/armory)
 "OA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8615,6 +8718,25 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"OU" = (
+/obj/item/mecha_parts/mecha_equipment/armor/anticcw_armor_booster{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/mecha_parts/mecha_equipment/air_tank/full{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "OV" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -8804,6 +8926,15 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack/gunrack,
+/obj/item/gun/energy/pulse/carbine/loyalpin{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/gun/energy/pulse/carbine/loyalpin{
+	pixel_x = 0;
+	pixel_y = -6
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
 "PF" = (
@@ -8892,10 +9023,14 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
 "PY" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/button/door/indestructible{
+	id = "XCCertmech";
+	name = "ERT Mech Shutters";
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/tdome/observation)
+/area/centcom/central_command_areas/armory)
 "PZ" = (
 /obj/structure/flora/tree/palm{
 	icon_state = "palm2"
@@ -9304,6 +9439,15 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack/gunrack,
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_x = 0;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
 "RP" = (
@@ -9412,10 +9556,13 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "Sp" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack/gunrack,
+/obj/item/gun/ballistic/shotgun/riot/sol,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
-/area/centcom/tdome/observation)
+/area/centcom/central_command_areas/armory)
 "Sq" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -9469,6 +9616,25 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
+"SI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/restraints/legcuffs/bola{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/restraints/legcuffs/bola{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/restraints/legcuffs/bola{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/armory)
 "SJ" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -9971,18 +10137,21 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "Vg" = (
-/obj/structure/rack,
 /obj/item/gun/energy/e_gun{
-	pixel_x = -3;
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_x = 0;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "Vh" = (
@@ -10049,11 +10218,8 @@
 /area/centcom/tdome/observation)
 "Vu" = (
 /obj/structure/closet/secure_closet/ert_med,
-/obj/machinery/vending/wallmed/directional/south{
-	use_power = 0
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
@@ -10123,15 +10289,13 @@
 /turf/open/floor/carpet/grimey,
 /area/centcom/central_command_areas/admin)
 "VM" = (
-/obj/structure/closet/secure_closet/ert_sec,
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/status_display/evac/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/emps,
+/obj/item/gun/energy/ionrifle,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "VO" = (
@@ -10171,14 +10335,13 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "VZ" = (
-/obj/structure/closet/secure_closet/ert_med,
-/obj/structure/sign/directions/medical{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe/rapidsyringe,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "Wa" = (
@@ -10202,8 +10365,14 @@
 /area/centcom/central_command_areas/evacuation)
 "Wd" = (
 /obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/wt550,
-/obj/item/flashlight/seclite,
+/obj/item/gun/ballistic/automatic/wt550{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /obj/structure/noticeboard/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -50218,12 +50387,12 @@ VO
 ST
 rY
 Ya
+Ju
 Ya
-aa
-aa
-aa
-aa
-aa
+Ya
+Ya
+Ya
+Ya
 QC
 rZ
 MS
@@ -50475,12 +50644,12 @@ bH
 sE
 Zv
 VZ
+Vu
+aI
+FB
+HW
+Hm
 Ya
-aa
-aa
-aa
-aa
-QC
 QC
 QC
 QC
@@ -50731,15 +50900,15 @@ bH
 bH
 sE
 sE
-Vu
+sE
+sE
+sE
+FB
+kn
+sE
 Ya
-aa
-aa
-aa
-aa
-QC
-PY
-QC
+XJ
+Sl
 hI
 MK
 pI
@@ -50988,15 +51157,15 @@ RV
 Sq
 gX
 sE
-yS
+fD
+Sp
+PY
 Ya
-aa
-aa
-aa
-aa
-Sp
-Pc
-Sp
+Oz
+sE
+Ya
+Xf
+Sl
 Qi
 oi
 pI
@@ -51245,15 +51414,15 @@ bA
 bj
 Pt
 sE
-FB
+SI
+Dq
+sE
+BS
+sE
+sE
 Ya
-aa
-aa
-aa
-aa
-QC
+XJ
 Sl
-QC
 PT
 Rh
 QC
@@ -51502,14 +51671,14 @@ bH
 bH
 sE
 sE
-IK
+sE
+sE
+sE
+FB
+sE
+sE
 Ya
-aa
-aa
-aa
-aa
-QC
-Hm
+XJ
 Sl
 Qi
 oi
@@ -51760,13 +51929,13 @@ RM
 PE
 sE
 VM
+yS
+wS
+FB
+bq
+OU
 Ya
-aa
-aa
-aa
-aa
-QC
-OE
+XJ
 Sl
 PT
 Rh
@@ -52017,12 +52186,12 @@ Ya
 Ya
 rY
 Ya
+Cu
 Ya
-Dq
-io
-io
-io
-QC
+Ya
+Ya
+Ya
+Ya
 Sl
 QC
 Qi
@@ -52273,11 +52442,11 @@ mQ
 io
 io
 io
-qw
-iu
-MF
-iu
-lN
+mQ
+mQ
+rK
+mQ
+rK
 iu
 eM
 Ze
@@ -52532,7 +52701,7 @@ kq
 io
 iu
 io
-Oz
+iu
 io
 iu
 io

--- a/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/misc.dm
@@ -53,6 +53,7 @@
 	new /obj/item/storage/medkit/brute(src)
 	new /obj/item/storage/medkit/regular(src)
 	new /obj/item/defibrillator/compact/combat/loaded/nanotrasen(src)
+	new /obj/item/gun/medbeam(src)
 
 /obj/structure/closet/secure_closet/ert_engi
 	name = "emergency response team engineer locker"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -73,7 +73,7 @@
 		/obj/item/storage/box/handcuffs = 1,
 	)
 	belt = /obj/item/storage/belt/security/full
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/security/night
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	additional_radio = /obj/item/encryptionkey/heads/hos
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Expands the CentCom Armory and adds more weapons, a mech and spare MedBeam to ERT Med's locker. Also gives ERT Sec Night Vision Sec HUDs.

Adds to the Armory:
2 Modular Rifles and Carbines
2 Pulse Carbines
1 M64 Shotgun with ammo boxes
A Durand with 3 weapons, armor boosters and air tank, along with upgrades for it

## Why it's Good for the Game

Allows ERT to be better armed when the armory is open to them.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
![image](https://github.com/user-attachments/assets/45123d6d-44da-4078-902c-7973a8fe2391)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: More weapons to Central Command's Armory
add: Security ERT now has NVGs and Medical ERT has spare MedBeams
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
