### PR TITLE
Adds announcements to NODE drones, Repeatable ore vents now get GPS priority

### DIFF
--- a/modular_iris/modules/mining/ore_vents.dm
+++ b/modular_iris/modules/mining/ore_vents.dm
@@ -1,0 +1,45 @@
+/obj/structure/ore_vent
+	var/drone_vent_name = null
+
+/mob/living/basic/node_drone/arrive(obj/structure/ore_vent/parent_vent)
+	. = ..()
+	if(isnull(attached_vent.drone_vent_name))
+		generate_vent_name(parent_vent)
+
+	aas_config_announce(/datum/aas_config_entry/node_start_excavation, list("VENT_NAME" = attached_vent.drone_vent_name), null, list(RADIO_CHANNEL_SUPPLY))
+
+/mob/living/basic/node_drone/pre_escape(success)
+	if(success)
+		if(isnull(attached_vent.drone_vent_name))
+			generate_vent_name(attached_vent)
+
+		aas_config_announce(/datum/aas_config_entry/node_end_excavation, list("VENT_NAME" = attached_vent.drone_vent_name), null, list(RADIO_CHANNEL_SUPPLY))
+	. = ..()
+
+/mob/living/basic/node_drone/proc/generate_vent_name(obj/structure/ore_vent/vent)
+	var/vent_name = ""
+	for(var/datum/material/resource as anything in vent.mineral_breakdown)
+		var/letters = html_decode(initial(resource.name))
+		vent_name = "[vent_name][letters[1]]"
+
+	vent.drone_vent_name = "[vent.boulder_size]-[uppertext(vent_name)]"
+
+/datum/aas_config_entry/node_start_excavation
+	name = "Cargo Notification: Node drone starting operation"
+	general_tooltip = "Announces when a miner starts to excavate an ore vent."
+	announcement_lines_map = list(
+		"Message" = "Node drone network report: Starting excavation of ore vent %VENT_NAME."
+	)
+	vars_and_tooltips_map = list(
+		"VENT_NAME" = "Will be replaced with the vent's ore information and size made up into a name",
+	)
+
+/datum/aas_config_entry/node_end_excavation
+	name = "Cargo Notification: Node drone ending operation"
+	general_tooltip = "Announces when a miner ends an ore vent excavation, be it a success or failure."
+	announcement_lines_map = list(
+		"Message" = "Node drone network report: Successfully excavated ore vent %VENT_NAME."
+	)
+	vars_and_tooltips_map = list(
+		"VENT_NAME" = "Will be replaced with the vent's ore information and size made up into a name",
+	)

--- a/modular_nova/modules/ghost_mining/code/ghost_vent.dm
+++ b/modular_nova/modules/ghost_mining/code/ghost_vent.dm
@@ -93,6 +93,10 @@
 	else
 		boulder_bounty = initial(boulder_bounty) //Just resets to what it started with. Yes, this is all this needs.
 
+	// IRIS ADDITION START
+	drone_vent_name = null
+	gps_name = "*New [gps_name]"
+	// IRIS ADDITION END
 	AddComponent(/datum/component/gps, gps_name) // We let GPS be a system to let people know when it resets
 
 
@@ -319,6 +323,7 @@
 
 /obj/structure/ore_vent/ghost_mining/boss/handle_wave_conclusion()
 	node = new /mob/living/basic/node_drone(loc) //We're spawning the vent after the boss dies, so the player can just focus on the boss.
+	node.attached_vent = src // IRIS ADDITION
 	SSblackbox.record_feedback("tally", "ore_vent_mobs_killed", 1, summoned_boss)
 	COOLDOWN_RESET(src, wave_cooldown)
 	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6782,6 +6782,7 @@
 #include "modular_iris\modules\loadouts\loadout_items\donator\iris_donator_loadout_datum_toys.dm"
 #include "modular_iris\modules\mining\megafauna_loot.dm"
 #include "modular_iris\modules\mining\mining_loot.dm"
+#include "modular_iris\modules\mining\ore_vents.dm"
 #include "modular_iris\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "modular_iris\modules\mob\living\frogs\guaranteed_common_frog.dm"
 #include "modular_iris\modules\mob\living\frogs\guaranteed_rare_frog.dm"


### PR DESCRIPTION

## About The Pull Request

Makes it so NODE drones now will tell to the cargo channel whenever a vent is starting its excavation, or if its SUCCESSFULLY excavated. (for boss vents, only the successfull message is broadcasted since there's not a fail condition)

After the first boss defeat of a repeatable ore vent, any future GPS signals emitted by the repeatable vent will have a star next to it, just like the kherial cuffs

## Why it's Good for the Game

Just like bitrunners have their messages about servers cooling down or research about stuff being researched, i think it'd be neat to have NODE drones inform cargo whenver an ore vent is starting or ending its excavation.
Be it for other miners knowing what materials are already automated and should not be prioritized for mining or just for cargo's chat to be a bit more livelly

Also the GPS thing is purelly because vents normally are at the bottom of the GPS, and the repeatable vents will just go there without any obvious tells that they are ready to go again, this makes it bad to keep track of if you wanna complete one multiple times.

## Proof of Testing

si
(Btw, the name is based on the boulder size and materials a vent has, so SI is silver and iron)

![image](https://github.com/user-attachments/assets/832c7e39-831d-4ce0-b4f7-5d0eb03241c4)

also i had one generate 15-PUG but not on a screenshot

## Changelog

:cl:
add: NODE mining drones now inform cargo whenever a vote is starting its excavation or ending it
qol: Repeatable ore vents are now at the top of the GPS list when available after the first boss defeat
/:cl:
