### PR TITLE
Makes monophobia not progress if you are SSD

### DIFF
--- a/code/datums/components/fearful/sources.dm
+++ b/code/datums/components/fearful/sources.dm
@@ -155,6 +155,10 @@
 	. = ..()
 	if (!.)
 		return
+	// IRIS ADDITION START -- Makes AFK people not die
+	if(owner.ssd_indicator)
+		return FALSE
+	// IRIS ADDITION END
 
 	var/check_radius = 7
 	if (owner.is_blind())


### PR DESCRIPTION

## About The Pull Request

Makes monophobia no longer buildup fear when a person is currently SSD

## Why it's Good for the Game

Someone suggested it in #suggestions and it seemed to have positive feedback from others, so dis exists now

## Proof of Testing

My 3 minute look at the code

## Changelog

:cl:
balance: monophobia no longer makes ssd people have their fears progressed
/:cl:
