### PR TITLE
Adds a one-way door to the interlink that lets you leave the grass area behind the arrivals shuttle incase you get stuck there somehow, this realistically wont ever happen but its good to have some safeties so if we have a player that does it they wont have to wait

### DIFF
--- a/_maps/map_files/generic/CentCom_nova_z2.dmm
+++ b/_maps/map_files/generic/CentCom_nova_z2.dmm
@@ -10489,10 +10489,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/interlink/departures)
-"kHZ" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/misc/dirt/planet,
-/area/centcom/holding/cafepark)
 "kIx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -14209,11 +14205,13 @@
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
 "pKV" = (
-/obj/effect/turf_decal/arrows/blue{
-	dir = 1
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark,
-/area/centcom/interlink/departures)
+/area/centcom/interlink)
 "pLq" = (
 /obj/structure/rack/wooden,
 /obj/item/dyespray{
@@ -35925,7 +35923,7 @@ amB
 amB
 amB
 amB
-amB
+pKV
 lPi
 lPi
 lPi


### PR DESCRIPTION

## About The Pull Request

Adds a one-way exit door to the interlink between the grass area behind the arrivals shuttle spot into the main late-join spawning area

## Why it's Good for the Game

You can actually get stuck there, so its good to have something you can leave with instead of asking people on comms to call it for you

## Changelog

:cl:
qol: added a one-way exit door between the grass interlink area behind the arrivals shuttle dock and the late-join interlink area
/:cl:
