### PR TITLE
Fixes the techstorage on void raptor having 2 duplicate rack boards and 3 missing rack boards

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -11358,7 +11358,6 @@
 /area/station/commons/fitness/recreation/entertainment)
 "dtj" = (
 /obj/structure/rack/shelf,
-/obj/effect/spawner/random/techstorage/security_all,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
@@ -11366,6 +11365,7 @@
 	c_tag = "Technology Storage";
 	name = "engineering camera"
 	},
+/obj/effect/spawner/random/techstorage/engineering_all,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "dto" = (
@@ -64047,6 +64047,8 @@
 "rSz" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/custom_shuttle,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "rSB" = (
@@ -76480,7 +76482,6 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "vkB" = (
 /obj/structure/rack/shelf,
-/obj/effect/spawner/random/techstorage/service_all,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -76488,6 +76489,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/spawner/random/techstorage/medical_all,
 /turf/open/floor/pod/dark,
 /area/station/engineering/storage/tech)
 "vkC" = (


### PR DESCRIPTION

## About The Pull Request

There were 2 security racks, and 2 service racks in the technology storage
So i deleted em, and added in the missing engineering, medical and shuttle racks

## Why it's Good for the Game

Map consistency

## Changelog

:cl:
fix: Fixes void raptor not having the proper technology storage racks
/:cl:
