### PR TITLE
Makes the language skill progressivelly give you more languages the higher level you are in it instead of giving a babel book at the end

### DIFF
--- a/modular_nova/modules/mentoring/language_skill.dm
+++ b/modular_nova/modules/mentoring/language_skill.dm
@@ -9,3 +9,40 @@
 	. = ..()
 	if(new_level >= SKILL_LEVEL_APPRENTICE && old_level < SKILL_LEVEL_APPRENTICE)
 		ADD_TRAIT(mind.current, TRAIT_LITERATE, SKILL_TRAIT)
+
+// IRIS ADDITION START
+/datum/skill/language
+	skill_item_path = /obj/item/clothing/accessory/language
+
+/datum/skill/language/level_gained(datum/mind/mind, new_level, old_level, silent)
+	. = ..()
+	var/datum/language_holder/language_holder = mind.current.get_language_holder()
+	var/list/learnable_languages = GLOB.all_languages.Copy() - language_holder.understood_languages
+	if(!length(learnable_languages)) // Once there are no more languages to learn, we make sure we stop running
+		return
+
+	var/language_amount = (new_level > 6 ? length(learnable_languages) : new_level) // If we're legendary, learn em all
+	var/learned_string = ""
+	for(var/index in 1 to language_amount)
+		if(!length(learnable_languages))
+			break
+
+		var/datum/language/language = pick_n_take(learnable_languages)
+		mind.current.grant_language(language, source = LANGUAGE_MIND)
+		if(index == 1)
+			learned_string = initial(language.name)
+			continue
+		learned_string = "[learned_string][index == language_amount ? " and" : ","] [initial(language.name)]"
+
+	to_chat(mind.current, span_nicegreen("I feel like my understanding of [learned_string] became a lot better!"))
+
+/obj/item/clothing/accessory/language
+	name = "language master badge"
+	desc = "A small medal showing your dedication to learning all languages across the galaxy"
+	icon_state = "bronze"
+
+/obj/item/clothing/accessory/language/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/skill_reward, /datum/skill/language)
+
+// IRIS ADDITION END


### PR DESCRIPTION

## About The Pull Request

Reworks the language skill to instead progressivelly award you languages as you get better in it rather than all at once at the end with a babel book
Makes the reward for reaching Legendary language abilities a badge instead of the babel book

## Why it's Good for the Game

Giving a babel book just feels lame, this makes the skill be not as of a random addition as it is at the moment while giving some flavor

## Proof of Testing

My pain with each skill only being created once and shared across all players

## Changelog

:cl:
add: The language skill now slowly feeds you languages instead of giving a babel book
/:cl:
