### PR TITLE
Makes it so any orbiters currently orbitting bitrunners follow them into bitdomains

### DIFF
--- a/code/modules/bitrunning/components/avatar_connection.dm
+++ b/code/modules/bitrunning/components/avatar_connection.dm
@@ -32,6 +32,8 @@
 	server_ref = WEAKREF(server)
 	server.avatar_connection_refs.Add(WEAKREF(src))
 
+	old_body.transfer_observers_to(avatar) // IRIS ADDITION
+
 	avatar.PossessByPlayer(old_body.key)
 	ADD_TRAIT(avatar, TRAIT_NO_MINDSWAP, REF(src)) // do not remove this one
 	ADD_TRAIT(old_body, TRAIT_MIND_TEMPORARILY_GONE, REF(src))
@@ -139,6 +141,8 @@
 		hosting_netpod = source
 
 	hosting_netpod?.disconnect_occupant(cause_damage)
+	var/mob/living/avatar = parent // IRIS ADDITION
+	avatar.transfer_observers_to(hosting_netpod.occupant) // IRIS ADDITION
 
 	var/obj/machinery/quantum_server/server = server_ref?.resolve()
 	server?.avatar_connection_refs.Remove(WEAKREF(src))


### PR DESCRIPTION

## About The Pull Request

**This would preferably be testmerged before full-merging due to ghost interaction**

Makes it so when orbitting a bitrunner them going into the bitrunning pod will automatically make you orbit the bitrunning avatar
Same applies in reverse, if the avatar dies or disconnects you'll be taken to the bitrunner

## Why it's Good for the Game

Makes orbitting a bit more comfortable

## Proof of Testing

Not well tested because needs ghosts and im not figuring out how to do multiplayer locally :3
Tho the transfer of ghosts works from bitavatars to bitrunners with 1 runtime, no info. Maybe caused because of the weirdness i had to do to test it with only myself?

## Changelog

:cl:
qol: Ghosts will now transfer between bitrunners and their bitavatars when exiting/entering domains
/:cl:
