### PR TITLE
Makes it so bitrunners can hear the station inside of bitdomains

### DIFF
--- a/_maps/safehouses/TEMPLATES/TEMPLATE.dmm
+++ b/_maps/safehouses/TEMPLATES/TEMPLATE.dmm
@@ -23,6 +23,10 @@
 "R" = (
 /turf/closed/wall,
 /area/virtual_domain/safehouse)
+"X" = (
+/obj/effect/bitrunning_relay_spawner,
+/turf/open/floor/plating,
+/area/virtual_domain/safehouse)
 
 (1,1,1) = {"
 R
@@ -69,7 +73,7 @@ a
 p
 N
 N
-p
+X
 R
 "}
 (7,1,1) = {"

--- a/_maps/safehouses/abductor.dmm
+++ b/_maps/safehouses/abductor.dmm
@@ -35,6 +35,10 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/virtual_domain/safehouse)
+"R" = (
+/obj/effect/landmark/bitrunning/bitrunning_relay,
+/turf/open/floor/plating/abductor,
+/area/virtual_domain/safehouse)
 
 (1,1,1) = {"
 n
@@ -81,7 +85,7 @@ a
 u
 o
 o
-n
+R
 a
 "}
 (7,1,1) = {"

--- a/_maps/safehouses/ancientmilsim_nova.dmm
+++ b/_maps/safehouses/ancientmilsim_nova.dmm
@@ -31,7 +31,6 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
@@ -128,6 +127,7 @@
 	dir = 6
 	},
 /obj/machinery/health_station/directional/east,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
 "D" = (
@@ -159,7 +159,6 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
@@ -248,7 +247,6 @@
 /obj/item/clothing/gloves/frontier_colonist,
 /obj/item/radio/headset/headset_faction/bowman,
 /obj/item/storage/pouch/ammo,
-/obj/item/storage/belt/security/webbing/blue,
 /obj/item/clothing/glasses/night,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)

--- a/_maps/safehouses/bathroom.dmm
+++ b/_maps/safehouses/bathroom.dmm
@@ -98,6 +98,7 @@
 "Z" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/blacklight/directional/west,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron/freezer,
 /area/virtual_domain/safehouse)
 

--- a/_maps/safehouses/den.dmm
+++ b/_maps/safehouses/den.dmm
@@ -136,6 +136,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/departments/cargo/directional/west,
 /obj/machinery/light/small/directional/west,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/pod,
 /area/virtual_domain/safehouse)
 "W" = (

--- a/_maps/safehouses/dig.dmm
+++ b/_maps/safehouses/dig.dmm
@@ -89,6 +89,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/plating,
 /area/virtual_domain/safehouse)
 "S" = (

--- a/_maps/safehouses/ice.dmm
+++ b/_maps/safehouses/ice.dmm
@@ -197,6 +197,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
 

--- a/_maps/safehouses/lavaland_boss.dmm
+++ b/_maps/safehouses/lavaland_boss.dmm
@@ -16,6 +16,11 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
 /area/virtual_domain/safehouse)
+"s" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
+/turf/open/floor/plating,
+/area/virtual_domain/safehouse)
 "v" = (
 /obj/structure/table,
 /obj/item/borg/upgrade/modkit/damage{
@@ -219,7 +224,7 @@ K
 O
 v
 a
-P
+s
 "}
 (5,1,1) = {"
 f

--- a/_maps/safehouses/mine.dmm
+++ b/_maps/safehouses/mine.dmm
@@ -79,8 +79,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/item/kirbyplants/random,
 /obj/structure/sign/departments/cargo/directional/south,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron/dark,
 /area/virtual_domain/safehouse)
 "X" = (

--- a/_maps/safehouses/shuttle.dmm
+++ b/_maps/safehouses/shuttle.dmm
@@ -146,6 +146,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/volcanic,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
 "M" = (

--- a/_maps/safehouses/shuttle_space.dmm
+++ b/_maps/safehouses/shuttle_space.dmm
@@ -80,6 +80,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/volcanic,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
 /turf/open/floor/iron,
 /area/virtual_domain/safehouse)
 "B" = (

--- a/_maps/safehouses/wood.dmm
+++ b/_maps/safehouses/wood.dmm
@@ -13,6 +13,11 @@
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/indestructible/hotelwood,
 /area/virtual_domain/safehouse)
+"r" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/landmark/bitrunning/bitrunning_relay,
+/turf/open/indestructible/hotelwood,
+/area/virtual_domain/safehouse)
 "s" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/landmark/bitrunning/cache_goal_turf,
@@ -79,7 +84,7 @@ i
 Z
 a
 a
-Z
+r
 i
 "}
 (3,1,1) = {"

--- a/code/modules/bitrunning/objects/quantum_console.dm
+++ b/code/modules/bitrunning/objects/quantum_console.dm
@@ -46,6 +46,7 @@
 	data["retries_left"] = length(server.exit_turfs) - server.retries_spent
 	data["broadcasting"] = server.broadcasting
 	data["broadcasting_on_cd"] = !COOLDOWN_FINISHED(server, broadcast_toggle_cd)
+	data["telecomms_radio"] = server.telecomms_radio // IRIS ADDITION
 
 	return data
 
@@ -86,6 +87,12 @@
 		if("broadcast")
 			server.toggle_broadcast()
 			return TRUE
+
+		// IRIS ADDITION START
+		if("radio")
+			server.toggle_radio()
+			return TRUE
+		// IRIS ADDITION END
 
 	return FALSE
 

--- a/code/modules/bitrunning/server/map_handling.dm
+++ b/code/modules/bitrunning/server/map_handling.dm
@@ -127,6 +127,13 @@
 			qdel(thing)
 			continue
 
+		// IRIS ADDITION
+		if(istype(thing, /obj/effect/landmark/bitrunning/bitrunning_relay))
+			if(telecomms_radio)
+				new /obj/machinery/telecomms/relay/preset/auto/bitrunning(thing.loc)
+			qdel(thing)
+			continue
+		// IRIS ADDITION
 		if(istype(thing, /obj/effect/landmark/bitrunning/permanent_exit))
 			var/turf/tile = get_turf(thing)
 			exit_turfs += tile

--- a/code/modules/bitrunning/server/util.dm
+++ b/code/modules/bitrunning/server/util.dm
@@ -159,6 +159,10 @@
 	var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit, pref, include_loadout = load_loadout) // NOVA EDIT CHANGE - ORIGINAL: var/mob/living/carbon/new_avatar = generate_avatar(get_turf(entry_atom), netsuit)
 	stock_gear(new_avatar, neo, generated_domain)
 
+	// IRIS ADDITION START
+	if(telecomms_radio)
+		new /obj/item/radio/bitrunning(new_avatar)
+	// IRIS ADDITION END
 	// Cleanup for domains with one time use custom spawns
 	if(!length(generated_domain.custom_spawns))
 		return new_avatar

--- a/modular_iris/modules/bitrunning/code/telecomms_relays.dm
+++ b/modular_iris/modules/bitrunning/code/telecomms_relays.dm
@@ -2,6 +2,7 @@
 	name = "bitrunning relay marker"
 
 /obj/machinery/telecomms/relay/preset/auto/bitrunning
+	circuit = null
 	freq_listening = list(FREQ_COMMON, FREQ_SUPPLY, FREQ_SCIENCE, FREQ_FACTION)
 	receiving = FALSE // Yes, receiving and not broadcasting, they are backwards
 

--- a/modular_iris/modules/bitrunning/code/telecomms_relays.dm
+++ b/modular_iris/modules/bitrunning/code/telecomms_relays.dm
@@ -1,0 +1,16 @@
+/obj/effect/landmark/bitrunning/bitrunning_relay
+	name = "bitrunning relay marker"
+
+/obj/machinery/telecomms/relay/preset/auto/bitrunning
+	freq_listening = list(FREQ_COMMON, FREQ_SUPPLY, FREQ_SCIENCE, FREQ_FACTION)
+	receiving = FALSE // Yes, receiving and not broadcasting, they are backwards
+
+/obj/item/radio/bitrunning
+	name = "internal bitrunner radio"
+	keyslot = /obj/item/encryptionkey/headset_bitrunning
+
+/obj/machinery/quantum_server
+	var/telecomms_radio = TRUE
+
+/obj/machinery/quantum_server/proc/toggle_radio()
+	telecomms_radio = !telecomms_radio

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6778,6 +6778,7 @@
 #include "modular_iris\modules\ashwalkers\code\items\ash_weapon.dm"
 #include "modular_iris\modules\autoimplanter\code\implanter.dm"
 #include "modular_iris\modules\bitrunning\code\quantum_console.dm"
+#include "modular_iris\modules\bitrunning\code\telecomms_relays.dm"
 #include "modular_iris\modules\blooper\atoms_movable.dm"
 #include "modular_iris\modules\blooper\bark.dm"
 #include "modular_iris\modules\blooper\bark_list.dm"

--- a/tgui/packages/tgui/interfaces/QuantumConsole.tsx
+++ b/tgui/packages/tgui/interfaces/QuantumConsole.tsx
@@ -31,6 +31,7 @@ type Data =
       scanner_tier: number;
       broadcasting: BooleanLike;
       broadcasting_on_cd: BooleanLike;
+      telecomms_radio: BooleanLike; // IRIS ADDITION
     }
   | {
       connected: 0;
@@ -96,7 +97,8 @@ export function QuantumConsole(props) {
   const { data } = useBackend<Data>();
 
   return (
-    <Window title="Quantum Console" width={500} height={500}>
+    // IRIS EDIT -- down there, width from 500 to 600
+    <Window title="Quantum Console" width={600} height={500}>
       <Window.Content>
         {!!data.connected && !data.ready && <LoadingScreen />}
         <AccessView />
@@ -117,6 +119,7 @@ function AccessView(props) {
     available_domains = [],
     broadcasting,
     broadcasting_on_cd,
+    telecomms_radio, // IRIS ADDITION
     generated_domain,
     occupants,
     points,
@@ -158,6 +161,19 @@ function AccessView(props) {
                   Broadcast
                 </Button.Checkbox>
               </Tooltip>
+              {/* IRIS ADDITION START */}
+              <Tooltip
+                content="Toggles whether the bitrunning server
+                  broadcasts station's radio into the bitdomain."
+              >
+                <Button.Checkbox
+                  checked={telecomms_radio}
+                  onClick={() => act('radio')}
+                >
+                  Transmit Radio
+                </Button.Checkbox>
+              </Tooltip>
+              {/* IRIS ADDITION END */}
               <Tooltip
                 content="Get a random domain for more rewards.
                   Already played domains are unlikelly to appear again." // IRIS EDIT - REMOVES POINTS FOR RANDOM DOMAINS.


### PR DESCRIPTION

## About The Pull Request

Adds in a new toggle near the broadcasting button that changes if a bitdomain spawns with the following:
A non-broadcasting relay is spawned inside of bitdomain safehouses
Radio's with bitrunner keys are spawned inside of bitrunners

## Why it's Good for the Game

Bitrunners are very often in bitdomains, making them miss out on a lot of comms dialogue, i think it'd be neat if they could hear the station.

## Proof of Testing

The "works on my machine" certification badge, tested using 40+ poly's over several tries

## Changelog

:cl:
add: Added a new toggle to the bitrunning console for it to broadcast station's radio into bitdomains
/:cl:
