### PR TITLE
Fixes Dominant Hand choices dropdown

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -124,10 +124,3 @@ GLOBAL_LIST_INIT(quirk_chipped_choice, list(
 	"Mast-Angl-Er" = /obj/item/skillchip/master_angler,
 	"Kommand" = /obj/item/skillchip/big_pointer,
 ))
-
-//IRIS EDIT ADDITION BEGIN - HANDEDNESS_QUIRK
-GLOBAL_LIST_INIT(side_choice_handedness, list(
-	"Dominant Left Hand",
-	"Dominant Right Hand",
-))
-//IRIS EDIT ADDITION END

--- a/modular_iris/modules/quirks/handedness/code/datums/client/preferences/handedness.dm
+++ b/modular_iris/modules/quirks/handedness/code/datums/client/preferences/handedness.dm
@@ -1,12 +1,10 @@
-// The issue might be in how we're defining the possible values
-
 /datum/preference/choiced/handedness
-    category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
-    savefile_key = "handedness"
-    savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "handedness"
+	savefile_identifier = PREFERENCE_CHARACTER
 
 /datum/preference/choiced/handedness/init_possible_values()
-    return list("Random", "Right Hand", "Left Hand")
+	return list("Random", "Right Hand", "Left Hand")
 
 /datum/preference/choiced/handedness/create_default_value()
 	return "Random"

--- a/modular_iris/modules/quirks/handedness/code/datums/client/preferences/handedness.dm
+++ b/modular_iris/modules/quirks/handedness/code/datums/client/preferences/handedness.dm
@@ -1,19 +1,21 @@
+// The issue might be in how we're defining the possible values
+
 /datum/preference/choiced/handedness
-	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
-	savefile_key = "handedness"
-	savefile_identifier = PREFERENCE_CHARACTER
+    category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+    savefile_key = "handedness"
+    savefile_identifier = PREFERENCE_CHARACTER
 
 /datum/preference/choiced/handedness/init_possible_values()
-	return list("Random") + GLOB.side_choice_handedness
+    return list("Random", "Right Hand", "Left Hand")
 
 /datum/preference/choiced/handedness/create_default_value()
 	return "Random"
 
 /datum/preference/choiced/handedness/is_accessible(datum/preferences/preferences)
-	if (!..(preferences))
+	if(!..())
 		return FALSE
 
-	return "Handedness" in preferences.all_quirks
+	return "Dominant Hand" in preferences.all_quirks
 
 /datum/preference/choiced/handedness/apply_to_human(mob/living/carbon/human/target, value)
 	return

--- a/modular_iris/modules/quirks/handedness/code/datums/quirk/handedness.dm
+++ b/modular_iris/modules/quirks/handedness/code/datums/quirk/handedness.dm
@@ -7,24 +7,24 @@
 	lose_text = span_notice("You feel able to control your left hand again.")
 
 /datum/quirk_constant_data/handedness
-    associated_typepath = /datum/quirk/handedness
-    customization_options = list(/datum/preference/choiced/handedness)
+	associated_typepath = /datum/quirk/handedness
+	customization_options = list(/datum/preference/choiced/handedness)
 
 /datum/quirk/handedness/add(client/client_source)
-    var/chosen_handedness = null
+	var/chosen_handedness = null
 
-    if(client_source?.prefs)
-        chosen_handedness = client_source.prefs.read_preference(/datum/preference/choiced/handedness)
+	if(client_source?.prefs)
+		chosen_handedness = client_source.prefs.read_preference(/datum/preference/choiced/handedness)
 
-    var/mob/living/carbon/human/human_holder = quirk_holder
-    if(chosen_handedness == "Left Hand")
-        gain_text = span_danger("You no longer feel able to accurately control your right hand.")
-        lose_text = span_notice("You feel able to control your right hand again.")
-        medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] right hand."
-        ADD_TRAIT(human_holder, TRAIT_HANDEDNESS_LEFT, QUIRK_TRAIT)
-    else
-        medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] left hand."
-        ADD_TRAIT(human_holder, TRAIT_HANDEDNESS, QUIRK_TRAIT)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(chosen_handedness == "Left Hand")
+		gain_text = span_danger("You no longer feel able to accurately control your right hand.")
+		lose_text = span_notice("You feel able to control your right hand again.")
+		medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] right hand."
+		ADD_TRAIT(human_holder, TRAIT_HANDEDNESS_LEFT, QUIRK_TRAIT)
+	else
+		medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] left hand."
+		ADD_TRAIT(human_holder, TRAIT_HANDEDNESS, QUIRK_TRAIT)
 
 /datum/quirk/handedness/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder

--- a/modular_iris/modules/quirks/handedness/code/datums/quirk/handedness.dm
+++ b/modular_iris/modules/quirks/handedness/code/datums/quirk/handedness.dm
@@ -7,23 +7,24 @@
 	lose_text = span_notice("You feel able to control your left hand again.")
 
 /datum/quirk_constant_data/handedness
-	associated_typepath = /datum/quirk/handedness
-	customization_options = list(/datum/preference/choiced/handedness)
+    associated_typepath = /datum/quirk/handedness
+    customization_options = list(/datum/preference/choiced/handedness)
 
 /datum/quirk/handedness/add(client/client_source)
-	var/side_choice = GLOB.side_choice_handedness[client_source?.prefs?.read_preference(/datum/preference/choiced/handedness)]
-	if(isnull(side_choice))  // Client gone or they chose a random side
-		side_choice = GLOB.side_choice_handedness[pick(GLOB.side_choice_handedness)]
+    var/chosen_handedness = null
 
-	var/mob/living/carbon/human/human_holder = quirk_holder
-	if(side_choice == "Dominant Left Hand")
-		gain_text = span_danger("You no longer feel able to accurately control your right hand.")
-		lose_text = span_notice("You feel able to control your right hand again.")
-		medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] right hand."
-		ADD_TRAIT(human_holder, TRAIT_HANDEDNESS_LEFT, QUIRK_TRAIT)
-	else
-		medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] left hand."
-		ADD_TRAIT(human_holder, TRAIT_HANDEDNESS, QUIRK_TRAIT)
+    if(client_source?.prefs)
+        chosen_handedness = client_source.prefs.read_preference(/datum/preference/choiced/handedness)
+
+    var/mob/living/carbon/human/human_holder = quirk_holder
+    if(chosen_handedness == "Left Hand")
+        gain_text = span_danger("You no longer feel able to accurately control your right hand.")
+        lose_text = span_notice("You feel able to control your right hand again.")
+        medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] right hand."
+        ADD_TRAIT(human_holder, TRAIT_HANDEDNESS_LEFT, QUIRK_TRAIT)
+    else
+        medical_record_text = "Patient demonstrates impaired adroitness when asked to use [human_holder.p_their()] left hand."
+        ADD_TRAIT(human_holder, TRAIT_HANDEDNESS, QUIRK_TRAIT)
 
 /datum/quirk/handedness/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder


### PR DESCRIPTION
## About The Pull Request
This fixes the Dominant Hand choices not showing up in the dropdown menu.
It also renames the choices to better fit the initial size of the dropdown menu (when not selecting).
## Why it's Good for the Game
Makes it so you can now choose this quirk properly!
## Proof of Testing
![cDa0O4Ry9L](https://github.com/user-attachments/assets/05b500a4-2db5-4a30-adf0-6feb1875dd31)
## Changelog
:cl:
fix: fixed choosing options for dominant hand quirk
/:cl: