### PR TITLE
Mutant Scanner Gate Mode

### DIFF
--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -51,6 +51,7 @@
 		SPECIES_PODPERSON,
 		SPECIES_GOLEM,
 		SPECIES_ZOMBIE,
+		SPECIES_MUTANT,
 	)
 	/// All scan modes available to the scanner
 	var/static/list/all_modes = list(
@@ -222,6 +223,10 @@
 					detected_thing = "Romerol infection"
 					if(scanned_human.get_organ_slot(ORGAN_SLOT_ZOMBIE))
 						beep = TRUE
+				//IRIS EDIT ADDITION BEGIN - MUTANT SCANNER GATE
+				if(detect_species_id == SPECIES_MUTANT)
+					detected_thing = "Proto-Viral infection"
+					if(scanned_human.GetComponent(/datum/component/mutant_infection))
 		if(SCANGATE_GUNS)
 			detected_thing = "Weapons"
 			if(isgun(thing))

--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -227,6 +227,8 @@
 				if(detect_species_id == SPECIES_MUTANT)
 					detected_thing = "Proto-Viral infection"
 					if(scanned_human.GetComponent(/datum/component/mutant_infection))
+						beep = TRUE
+				//IRIS EDIT ADDITION END - MUTANT SCANNER GATE
 		if(SCANGATE_GUNS)
 			detected_thing = "Weapons"
 			if(isgun(thing))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I'll be honest, I've seen the HNZ-1 Mutants event ran quite a few times, and they're basically just New Zombies, so I decided to add a feature from Old Regular Zombies to Mutants! Don't worry about how the button is labelled "High-Functioning Mutant" in the species list, that's how zombies are done too as a quirk of how the species selection and the zombie/mutant species setup is done. It still detects infectious ones.

Basically, This adds a new species to scan under with its own special little bit same as zombies, you walk in with the mutant component and it blares an alarm. revolutionary, i know.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
~~I like weewoo alarms~~
It's a feature of the original zombies version, and specifically me ~~and noone else probably~~ would probably like it back. It'd be cool for setting up a checkpoint into a safe zone!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
~~trust me bro~~ my computer would explode if i tried to record it, it was at 100% CPU. This is half in part due to me watching a discord stream while testing. But I tested! and it works! Uninfected? No alarm. Infected but before theyre actually a mutant (dormant phase)? Alarm. Infected and dead? Alarm. Infected and actually a mutant? Alarm.
If i absolutely must, i can if asked of me.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Tractor Maam
add: Added a Mutant mode to the scanner gates species scanner. It also detects dormant infected! wow! Have fun making safe zone checkpoints!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
