### PR TITLE
Adds a configurable soft-cap to transfer votes

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -6,6 +6,7 @@ $include comms.txt
 $include logging.txt
 $include resources.txt
 $include nova/config_nova.txt
+$include iris/config_iris.txt
 $include interviews.txt
 $include lua.txt
 $include auxtools.txt

--- a/config/iris/config_iris.txt
+++ b/config/iris/config_iris.txt
@@ -1,0 +1,10 @@
+## The amount of votes that gets added each time transfer vote is called onto the "transfer" option
+## 0 / commenting it out disables it
+## 10 would mean every time a transfer vote is called an extra 10% of all player votes is added onto transferring
+TRANSFER_PROGRESSION 0
+
+## The maximum amount that progression can reach, examples:
+## 10 would mean progression can at most add 10% of the players votes into transfer
+## 99 would mean progression can eventually require every player to vote on continue or the vote transfers
+## values above 100 would force the transfer vote to eventually pass, for more fine control use nova's transfer soft-cap system
+TRANSFER_MAXIMUM 90

--- a/modular_iris/modules/transfer_softcap/code/config.dm
+++ b/modular_iris/modules/transfer_softcap/code/config.dm
@@ -1,0 +1,7 @@
+/datum/config_entry/number/transfer_progression
+	config_entry_value = 0
+	min_val = 0
+
+/datum/config_entry/number/transfer_maximum
+	config_entry_value = 90
+	min_val = 0

--- a/modular_iris/modules/transfer_softcap/code/transfer_vote.dm
+++ b/modular_iris/modules/transfer_softcap/code/transfer_vote.dm
@@ -1,0 +1,20 @@
+#define CHOICE_TRANSFER "Initiate Crew Transfer"
+
+/datum/vote/transfer_vote/get_vote_result(list/non_voters)
+	var/transfer_progression = CONFIG_GET(number/transfer_progression)
+	if(transfer_progression)
+		var/static/progression = 0
+		var/maximum_progression = CONFIG_GET(number/transfer_maximum)
+		transfer_progression *= 0.01 // config can't handle integers, its so fuckin over
+		maximum_progression *= 0.01
+		progression = min(transfer_progression + progression, maximum_progression)
+
+		var/total_votes = 0
+		for(var/option in choices)
+			total_votes += choices[option]
+
+		choices[CHOICE_TRANSFER] += (total_votes * progression)
+
+	return ..()
+
+#undef CHOICE_TRANSFER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6928,6 +6928,8 @@
 #include "modular_iris\modules\research\code\designs\quantum_part_designs.dm"
 #include "modular_iris\modules\research\code\techweb\all_nodes.dm"
 #include "modular_iris\modules\sound\sounds.dm"
+#include "modular_iris\modules\transfer_softcap\code\config.dm"
+#include "modular_iris\modules\transfer_softcap\code\transfer_vote.dm"
 #include "modular_iris\modules\transmutation_fluid\code\transmutation_fluid.dm"
 #include "modular_iris\modules\unusual_biochemistry\blood_types.dm"
 #include "modular_iris\monke_ports\code\game\turfs\open\floor\misc_floor.dm"


### PR DESCRIPTION

## About The Pull Request

Adds a new configurable soft-cap to transfer votes, alongside support for iris configs
the configs are:
TRANSFER_PROGRESSION -- How much extra % of votes is added each time a new transfer vote is called
TRANSFER_MAXIMUM -- How much can the extra % of votes be at the maximum
more detailed descriptions with examples in the config file itself

## Why it's Good for the Game

There's some discussion of soft-cap votes on discord, so it seems like it'd be neat

## Proof of Testing

Video of it in action (settings are 10% progression, 90% cap)

https://github.com/user-attachments/assets/0a1b2331-4e4b-459b-b260-fd8ecf890949

## Changelog

:cl:
add: Added soft-cap transfer votes
config: added 2 new configs for soft-cap transfer votes, by default being disabled
/:cl:
