### PR TITLE
Makes the Roboticist Spraycan printable at Science Protolathe

### DIFF
--- a/code/modules/research/techweb/nodes/robo_nodes.dm
+++ b/code/modules/research/techweb/nodes/robo_nodes.dm
@@ -7,6 +7,7 @@
 		"botnavbeacon",
 		"mechfab",
 		"paicard",
+		"spraycan_roboticist", // Iris Addition
 	)
 
 /datum/techweb_node/exodrone

--- a/modular_iris/modules/research/code/designs/misc_designs.dm
+++ b/modular_iris/modules/research/code/designs/misc_designs.dm
@@ -7,3 +7,13 @@
 	build_path = /obj/item/disk/plantgene
 	category = list("Electronics")
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/spraycan/roboticist
+	name = "Roboticist Spraycan"
+	desc = "Paint for restyling unattached robotic limbs. Sadly doesn't shine like chrome."
+	id = "spraycan_roboticist"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT)
+	build_path = /obj/item/toy/crayon/spraycan/roboticist
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_TOOLS + RND_SUBCATEGORY_EQUIPMENT_SCIENCE)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says, makes the roboticist spraycan printable on the science lathe, no longer restricting it to map/admin-spawned only.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

cause it should be a thing already

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Roboticist Spraycan to Science Lathe, under Science Equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
