### PR TITLE
Registered Prescription Quirk From Doppler

### DIFF
--- a/modular_iris/modules/quirks/prescription.dm
+++ b/modular_iris/modules/quirks/prescription.dm
@@ -1,0 +1,131 @@
+// QUIRK PORTED FROM DOPPLER: https://github.com/DopplerShift13/DopplerShift/pull/596
+/datum/quirk/item_quirk/prescription
+	name = "Registered Prescription"
+	desc = "You have a medication registered with the pharmacy. Your medical records will be updated to reflect this, and medical staff will do their best to provide you with a supply for the shift."
+	/// Name of prescribed reagent.
+	var/prescription_reagent_name
+	/// Amount of prescribed reagent per item.
+	var/prescription_reagent_amount
+	/// Amount of items prescribed.
+	var/prescription_item_amount
+	/// What item our prescription comes in.
+	var/prescription_application_method
+	gain_text = span_notice("You feel like you need to take your prescribed medication...")
+	lose_text = span_notice("You feel like you don't need a prescription anymore.")
+	medical_record_text = ""
+	value = 0
+	icon = FA_ICON_PRESCRIPTION_BOTTLE_MEDICAL
+
+/datum/quirk/item_quirk/prescription/post_add()
+	var/obj/machinery/announcement_system/aas = get_announcement_system(source = src)
+	if (aas)
+		aas.broadcast(medical_record_text, list(RADIO_CHANNEL_MEDICAL))
+
+/datum/quirk/item_quirk/prescription/add_unique(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	prescription_reagent_name = client_source?.prefs.read_preference(/datum/preference/text/prescription_reagent_name)
+	prescription_reagent_amount = client_source?.prefs.read_preference(/datum/preference/numeric/prescription_reagent_amount)
+	prescription_item_amount = client_source?.prefs.read_preference(/datum/preference/numeric/prescription_item_amount)
+	prescription_application_method = client_source?.prefs.read_preference(/datum/preference/choiced/prescription_application_method)
+	medical_record_text = "[human_holder.name] has been prescribed [prescription_item_amount] [LOWER_TEXT(prescription_application_method)] of [prescription_reagent_name], with a dose of [prescription_reagent_amount] units per. Please produce this prescription and call them to medical when it is ready."
+	give_item_to_holder(/obj/item/storage/pill_bottle, list(LOCATION_BACKPACK, LOCATION_HANDS), flavour_text = "You are prescribed [prescription_item_amount] [LOWER_TEXT(prescription_application_method)] of [prescription_reagent_name], with a dose of [prescription_reagent_amount] units per.")
+
+/datum/quirk/item_quirk/prescription/remove()
+
+/datum/quirk_constant_data/prescription
+	associated_typepath = /datum/quirk/item_quirk/prescription
+	customization_options = list(
+		/datum/preference/text/prescription_reagent_name,
+		/datum/preference/numeric/prescription_reagent_amount,
+		/datum/preference/numeric/prescription_item_amount,
+		/datum/preference/choiced/prescription_application_method,
+	)
+
+// REAGENT NAME
+
+/datum/preference/text/prescription_reagent_name
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "prescription_reagent_name"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 32
+
+/datum/preference/text/prescription_reagent_name/create_default_value()
+	return "Psicodine"
+
+/datum/preference/text/prescription_reagent_name/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/text/prescription_reagent_name/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Registered Prescription" in preferences.all_quirks
+
+/datum/preference/text/prescription_reagent_name/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+// NUMBER OF UNITS PER ITEM
+
+/datum/preference/numeric/prescription_reagent_amount
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "prescription_reagent_amount"
+	savefile_identifier = PREFERENCE_CHARACTER
+	minimum = 1
+	maximum = 50
+
+/datum/preference/numeric/prescription_reagent_amount/create_default_value()
+	return 1
+
+/datum/preference/numeric/prescription_reagent_amount/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Registered Prescription" in preferences.all_quirks
+
+/datum/preference/numeric/prescription_reagent_amount/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+// HOW MANY ITEMS?
+
+/datum/preference/numeric/prescription_item_amount
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "prescription_item_amount"
+	savefile_identifier = PREFERENCE_CHARACTER
+	minimum = 1
+	maximum = 10
+
+/datum/preference/numeric/prescription_item_amount/create_default_value()
+	return 1
+
+/datum/preference/numeric/prescription_item_amount/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Registered Prescription" in preferences.all_quirks
+
+/datum/preference/numeric/prescription_item_amount/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+// APPLICATION METHOD
+
+/datum/preference/choiced/prescription_application_method
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "prescription_application_method"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+
+/datum/preference/choiced/prescription_application_method/init_possible_values()
+	return assoc_to_keys(list("Pills","Patches","Bottles"))
+
+/datum/preference/choiced/prescription_application_method/create_default_value()
+	return pick(list("Pills","Patches","Bottles"))
+
+/datum/preference/choiced/prescription_application_method/is_accessible(datum/preferences/preferences)
+	if (!..())
+		return FALSE
+
+	return "Registered Prescription" in preferences.all_quirks
+
+/datum/preference/choiced/prescription_application_method/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6917,6 +6917,7 @@
 #include "modular_iris\modules\quirks\floating_items.dm"
 #include "modular_iris\modules\quirks\limp.dm"
 #include "modular_iris\modules\quirks\paranoia.dm"
+#include "modular_iris\modules\quirks\prescription.dm"
 #include "modular_iris\modules\quirks\salt_vulnerability.dm"
 #include "modular_iris\modules\quirks\somatic_volatility.dm"
 #include "modular_iris\modules\quirks\stowaway.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/iris/prescription.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/iris/prescription.tsx
@@ -1,0 +1,27 @@
+import {
+  Feature,
+  FeatureChoiced,
+  FeatureNumberInput,
+  FeatureShortTextInput,
+} from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
+
+export const prescription_reagent_name: Feature<string> = {
+  name: 'Label of Prescription',
+  component: FeatureShortTextInput,
+};
+
+export const prescription_application_method: FeatureChoiced = {
+  name: 'Method of Application',
+  component: FeatureDropdownInput,
+};
+
+export const prescription_item_amount: Feature<number> = {
+  name: 'Prescribed Amount',
+  component: FeatureNumberInput,
+};
+
+export const prescription_reagent_amount: Feature<number> = {
+  name: 'Units Per',
+  component: FeatureNumberInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports the registered prescription quirk from https://github.com/DopplerShift13/DopplerShift/pull/596

This 0 cost quirk notifies medical when you arrive that you have a prescription for something, including the method of reagent application and dosage. Players can write whatever they want in the field. This quirk does NOT spawn you with the prescription chem itself, it only serves to notify medical a prescription is in effect.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Plenty of characters need certain medicines to live, and further still want to have prescriptions for flavor. This helps bridge that gap without forcing chemists to look through every person's records (because you know the average doctor doesn't). Helps mitigate players needing to speedrun to medical and beg the chemist for something. 

Bonus points, the ability to write Whatever You Want in the prescription field allows people to have prescriptions for chems that don't exist in ss13! Just have the chemist whip up a water pill and call it good. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/7ea53a40-2a5b-4104-ac0c-47b7324dd4c3)
![image](https://github.com/user-attachments/assets/b1ebee48-ef16-48a0-9e2c-d3f0e695fbf1)
![image](https://github.com/user-attachments/assets/827c4f3e-b730-4aa9-b403-ec26300e7a7a)


</details>

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the Registered Prescription neutral quirk, allowing you to write a (simple) custom prescription and have it given to medical as soon as you board the station!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
