### PR TITLE
Adds Balloon Alerts To Xenohybrid Abilities

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -142,8 +142,11 @@ Doesn't work on other aliens/AI.*/
 		return FALSE
 
 	log_directed_talk(owner, chosen_recipient, to_whisper, LOG_SAY, tag = "alien whisper")
-	chosen_recipient.balloon_alert(chosen_recipient, "you hear a voice") // IRIS ADDITION: Adds balloon popup
+	if(chosen_recipient.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat)) // IRIS EDIT: Makes xeno telepathy consistent with normal telepathy
+		chosen_recipient.create_chat_message(chosen_recipient, chosen_recipient.get_selected_language(), to_whisper, list("italics"))
 	to_chat(chosen_recipient, "[span_noticealien("You hear a strange, alien voice in your head...")][to_whisper]")
+	if(owner.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat)) // IRIS EDIT: Makes xeno telepathy consistent with normal telepathy
+		owner.create_chat_message(owner, owner.get_selected_language(), to_whisper, list("italics"))
 	to_chat(owner, span_noticealien("You said: \"[to_whisper]\" to [chosen_recipient]"))
 	for(var/mob/dead_mob as anything in GLOB.dead_mob_list)
 		if(!isobserver(dead_mob))

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -137,10 +137,12 @@ Doesn't work on other aliens/AI.*/
 	if(QDELETED(chosen_recipient) || QDELETED(src) || QDELETED(owner) || !IsAvailable(feedback = TRUE) || !to_whisper)
 		return FALSE
 	if(chosen_recipient.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
+		owner.balloon_alert(owner, "foiled!") // IRIS ADDITION: Adds balloon popup
 		to_chat(owner, span_warning("As you reach into [chosen_recipient]'s mind, you are stopped by a mental blockage. It seems you've been foiled."))
 		return FALSE
 
 	log_directed_talk(owner, chosen_recipient, to_whisper, LOG_SAY, tag = "alien whisper")
+	chosen_recipient.balloon_alert(chosen_recipient, "you hear a voice") // IRIS ADDITION: Adds balloon popup
 	to_chat(chosen_recipient, "[span_noticealien("You hear a strange, alien voice in your head...")][to_whisper]")
 	to_chat(owner, span_noticealien("You said: \"[to_whisper]\" to [chosen_recipient]"))
 	for(var/mob/dead_mob as anything in GLOB.dead_mob_list)
@@ -179,6 +181,7 @@ Doesn't work on other aliens/AI.*/
 		return FALSE
 
 	if(get_dist(owner, donation_target) > 1)
+		owner.balloon_alert(owner, "too far away") // IRIS ADDITION: Adds balloon popup
 		to_chat(owner, span_noticealien("You need to be closer!"))
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Makes xeno abilities consistent with analogous powers such as telepathy.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: xenohybrid abilities now have balloon alerts to provide feedback
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
