### PR TITLE
Be Not Afraid: Less Lethal Fear & Monophobia Buff

### DIFF
--- a/code/datums/components/fearful/effects.dm
+++ b/code/datums/components/fearful/effects.dm
@@ -48,7 +48,9 @@
 	if (terror_buildup > TERROR_BUILDUP_TERROR || SPT_PROB(1 + FEAR_SCALING(4, TERROR_BUILDUP_FEAR, TERROR_BUILDUP_TERROR), seconds_per_tick))
 		owner.set_stutter_if_lower(10 SECONDS)
 
+/// IRIS REMOVAL: Fear will no longer cause your heart to give out, since that's lame in a lowpop setting
 /// Can randomly give you some oxyloss, and cause a heart attack past TERROR_BUILDUP_HEART_ATTACK
+/*
 /datum/terror_handler/heart_problems
 	handler_type = TERROR_HANDLER_EFFECT
 	default = TRUE
@@ -80,6 +82,7 @@
 	)
 	owner.apply_status_effect(/datum/status_effect/heart_attack)
 	owner.Unconscious(20 SECONDS)
+*/
 
 /// Low chance to vomit when terrified, increases significantly during panic attacks
 /datum/terror_handler/vomiting

--- a/code/datums/components/fearful/sources.dm
+++ b/code/datums/components/fearful/sources.dm
@@ -149,7 +149,7 @@
 
 /// Makes the owner afraid of being alone
 /datum/terror_handler/simple_source/monophobia
-	buildup_per_second = 2.5 // Pretty low, ~4 minutes to reach passive cap
+	buildup_per_second = 0.5 // IRIS EDIT: Made it scale 5x slower. ORIGINAL COMMENT: Pretty low, ~4 minutes to reach passive cap
 
 /datum/terror_handler/simple_source/monophobia/check_condition(seconds_per_tick, terror_buildup)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes heart attacks triggering off of the fear status condition, approved by Synth. 
Also nerfs monophobia's scaling to the ground, slowing fear gain by 5x.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
First off, the heart attack removal: It's Dumb. Most sources of fear accumulate rapidly, but frankly, the other consequences (hyperventilation, screen shake, stuttering) are enough to simulate terror without Outright Death. Synth gave me the go-ahead to remove it so I am.
<details>
<summary>As for the monophobia...</summary>

![image](https://github.com/user-attachments/assets/ce57a401-1e6b-4784-9166-e26d5cb34ef8)

</details>
The person who originally wrote the code honestly believed four minutes of isolation was a fair amount before you got into heart attack territory. That's dumb, and stupid, and I hate it. It would take a whopping 60 seconds with the old fear value before you started trembling, and two minutes before you started throwing up. That's dumb. I've slowed it down by 5x in this PR, so you have five minutes of isolation before you start to shake and ten before you start getting the more extreme effects. Around the seventeen minute mark you should start experiencing proper panic attacks, which can cause oxy damage, so it's hardly free.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
<details>
<summary>Terror value hit 300 (the second stage of fear) at the ten minute mark, which is the expected rate of progress with the tweaked values. </summary>

![image](https://github.com/user-attachments/assets/0673fe88-13cf-42c4-be86-18ce94c3e4cf)

</details>




<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: You will no longer experience a heart attack at high fear levels (though you can certainly asphyxiate through a panic attack). 
balance: Monophobia progresses much slower than before. It now takes five minutes of isolation for stage one of fear, ten for stage two, and close to seventeen minutes for a full blown panic attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
