### PR TITLE
Adds Runechat Support To AI Cameras

### DIFF
--- a/modular_nova/modules/roleplay_do/code/do_verbs.dm
+++ b/modular_nova/modules/roleplay_do/code/do_verbs.dm
@@ -42,7 +42,12 @@
 		if((ghost.client?.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers))
 			ghost.show_message(span_emote(message_with_name))
 
+	// IRIS EDIT: Adds runechat support for AI Cameras
 	for(var/mob/receiver in viewers)
 		receiver.show_message(span_emote(message_with_name), alt_msg = span_emote(message_with_name))
 		if (receiver.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
-			create_chat_message(usr, null, message, null, EMOTE_MESSAGE)
+			for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
+				if(istype(usr, /mob/living/silicon/ai) && (ai.eyeobj in viewers))
+					create_chat_message(ai.eyeobj, null, message, null, EMOTE_MESSAGE)
+				else
+					create_chat_message(usr, null, message, null, EMOTE_MESSAGE)

--- a/modular_nova/modules/verbs/code/looc.dm
+++ b/modular_nova/modules/verbs/code/looc.dm
@@ -86,7 +86,12 @@
 		if(mob.runechat_prefs_check(hearing) && hearing.client?.prefs.read_preference(/datum/preference/toggle/enable_looc_runechat))
 			// EMOTE is close enough. We don't want it to treat the raw message with languages.
 			// I wish it didn't include the asterisk but it's modular this way.
-			hearing.create_chat_message(mob, raw_message = "(LOOC: [msg])", runechat_flags = EMOTE_MESSAGE)
+			// IRIS EDIT: Adds runechat support for AI Cameras
+			for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
+				if(istype(usr, /mob/living/silicon/ai) && (ai.eyeobj in heard))
+					hearing.create_chat_message(ai.eyeobj, raw_message = "(LOOC: [msg])", runechat_flags = EMOTE_MESSAGE)
+				else
+					hearing.create_chat_message(mob, raw_message = "(LOOC: [msg])", runechat_flags = EMOTE_MESSAGE)
 
 		if (is_holder)
 			continue //admins are handled afterwards


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds runechat support to AI cameras, making an AI's Do and LOOC actions appear following their camera rather than their core. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
The AI was given the ability to use both the Do and LOOC actions through their primary camera. The issue: Nobody added runechat support to it! All this PR does is make it more obvious when the AI Does A Thing. That's a net good, I think. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
![image](https://github.com/user-attachments/assets/15690634-c15b-49ea-8810-ad9ff157527a)

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Added runechat support to AI Cameras for Do and LOOC. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
