### PR TITLE
Fixes roundstart air alarms in kilo xenobiology

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -28333,6 +28333,10 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"iuw" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "iuz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29134,6 +29138,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "iFm" = (
@@ -46874,6 +46879,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
+"ojB" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "ojG" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -62402,6 +62411,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "sRa" = (
@@ -79110,10 +79120,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
-"xRZ" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "xSp" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/bot_white,
@@ -79327,6 +79333,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "xVC" = (
@@ -117853,7 +117860,7 @@ efq
 fwr
 bMc
 lwe
-lwe
+iuw
 vJc
 cXW
 usG
@@ -118367,7 +118374,7 @@ jLn
 oqo
 oqo
 oqo
-lwe
+ojB
 vJc
 lYK
 kwu
@@ -118859,7 +118866,7 @@ aeu
 aeu
 vJc
 jhN
-xRZ
+ndy
 wRn
 vJc
 aZN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Also adds firelocks to some science doors that lacked them for some reason.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Roundstart alarms bad
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

nuh im doing it while in game lmao

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Fixed roundstart air alarms in kilo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
