### PR TITLE
Disables underworld connections blacklist from cargo guards

### DIFF
--- a/code/__DEFINES/~~iris_defines/jobs.dm
+++ b/code/__DEFINES/~~iris_defines/jobs.dm
@@ -1,2 +1,5 @@
-//Adds restriction for all crew jobs except Assistant
+///Adds restriction for all crew jobs except Assistant
 #define JOB_RESTRICTED_QUIRKS "Stowaway" = TRUE
+
+///Shady guard for the shady command member
+#define GUARD_RESTRICTED_QUIRKS_CARGO "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE, "Stowaway" = TRUE

--- a/modular_nova/modules/customization/modules/jobs/_job.dm
+++ b/modular_nova/modules/customization/modules/jobs/_job.dm
@@ -174,7 +174,7 @@
 	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/customs_agent
-	banned_quirks = list(GUARD_RESTRICTED_QUIRKS)
+	banned_quirks = list(GUARD_RESTRICTED_QUIRKS_CARGO) //IRIS EDIT
 	required_languages = list(/datum/language/common = LANGUAGE_SPOKEN)
 
 /datum/job/bouncer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Separates cargo guard quirk blacklist from other departmental guards, like quartermaster has it already.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
It makes no sense that quartermasters underlings can't be as shady as the head of the whole department.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

Checked if they aren't blacklisted any more, works fine

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Customs agents can be corrupt again, just like their boss is
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
