### PR TITLE
Fixes universal scanners selling objects

### DIFF
--- a/modular_iris/modules/cargo_bounties/code/console.dm
+++ b/modular_iris/modules/cargo_bounties/code/console.dm
@@ -102,8 +102,16 @@
 		return FALSE
 
 	for(var/datum/bounty/cargo_bounty as anything in GLOB.cargo_bounties)
-		if(cargo_bounty.ship(exported_item))
+		if(cargo_bounty.applies_to(exported_item))
 			return TRUE
+
+/datum/export/bounty/sell_object(obj/sold_item, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
+	. = ..()
+	if(!dry_run)
+		for(var/datum/bounty/cargo_bounty as anything in GLOB.cargo_bounties)
+			if(cargo_bounty.ship(sold_item))
+				return EXPORT_SOLD
+		return EXPORT_NOT_SOLD
 
 /datum/export/bounty/total_printout(datum/export_report/ex, notes = TRUE)
 	return "" // We don't care


### PR DESCRIPTION

## About The Pull Request

Fixes universal scanners selling anything they touch

## Why it's Good for the Game

Bug, a very bad one that was not caught during TM's or local testing for the private cargo bounty PR

## Changelog

:cl:
fix: universal scanners no longer can instantly sell objects
/:cl:
