### PR TITLE
Emergency patch -- Limits minebots to 10

### DIFF
--- a/code/__DEFINES/~~iris_defines/_globalvars/minebots.dm
+++ b/code/__DEFINES/~~iris_defines/_globalvars/minebots.dm
@@ -1,0 +1,1 @@
+GLOBAL_VAR(minebot_amount)

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -44,7 +44,7 @@
 			var/true_amount = (groceries[item] + GLOB.minebot_amount)
 			if(true_amount > 10)
 				groceries[item] = (10 - GLOB.minebot_amount)
-			if(groceries[item] == 0)
+			if(groceries[item] <= 0)
 				groceries.Remove(item)
 				continue
 		// IRIS ADDITION END

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -39,8 +39,21 @@
 /obj/machinery/computer/order_console/mining/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	var/list/things_to_order = list()
 	for(var/datum/orderable_item/item as anything in groceries)
+		// IRIS ADDITION START
+		if(istype(item, /datum/orderable_item/toys_drones/mining_drone))
+			var/true_amount = (groceries[item] + GLOB.minebot_amount)
+			if(true_amount > 10)
+				groceries[item] = (10 - GLOB.minebot_amount)
+			if(groceries[item] == 0)
+				groceries.Remove(item)
+				continue
+		// IRIS ADDITION END
 		things_to_order[item.purchase_path] = groceries[item]
 
+	// IRIS ADDITION START
+	if(!length(things_to_order))
+		return
+	// IRIS ADDITION END
 	var/datum/supply_pack/custom/mining_pack = new(
 		purchaser = purchaser, \
 		cost = get_total_cost(), \

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -189,8 +189,21 @@ GLOBAL_LIST_EMPTY(order_console_products)
 					stack_trace("[src] somehow delivered [item] which is not purchasable at this order console.")
 					grocery_list.Remove(item)
 					continue
+				// IRIS ADDITION START
+				if(istype(item, /datum/orderable_item/toys_drones/mining_drone))
+					var/true_amount = (grocery_list[item] + GLOB.minebot_amount)
+					if(true_amount > 10)
+						grocery_list[item] = (10 - GLOB.minebot_amount)
+					if(grocery_list[item] == 0)
+						grocery_list.Remove(item)
+						continue
+				// IRIS ADDITION END
 				for(var/amt in 1 to grocery_list[item])//every order amount
 					ordered_paths += item.purchase_path
+			// IRIS ADDITION START
+			if(!length(ordered_paths))
+				return
+			// IRIS ADDITION END
 			podspawn(list(
 				"target" = get_turf(living_user),
 				"style" = /datum/pod_style/advanced,

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -194,7 +194,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 					var/true_amount = (grocery_list[item] + GLOB.minebot_amount)
 					if(true_amount > 10)
 						grocery_list[item] = (10 - GLOB.minebot_amount)
-					if(grocery_list[item] == 0)
+					if(grocery_list[item] <= 0)
 						grocery_list.Remove(item)
 						continue
 				// IRIS ADDITION END

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -92,7 +92,7 @@
 
 // IRIS ADDITION START
 /datum/voucher_set/mining/minebot_kit/spawn_set(atom/spawn_loc)
-	if(GLOB.minebot_amount <= 10)
+	if(GLOB.minebot_amount >= 10)
 		set_items -= /mob/living/basic/mining_drone
 	return ..()
 // IRIS ADDITION END

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -90,6 +90,12 @@
 		/obj/item/borg/upgrade/modkit/minebot_passthrough,
 	)
 
+// IRIS ADDITION START
+/datum/voucher_set/mining/minebot_kit/spawn_set(atom/spawn_loc)
+	if(GLOB.minebot_amount == 10)
+		set_items -= /mob/living/basic/mining_drone
+	return ..()
+// IRIS ADDITION END
 /datum/voucher_set/mining/conscription_kit
 	name = "Mining Conscription Kit"
 	description = "Contains a whole new mining starter kit for one crewmember, consisting of a proto-kinetic accelerator, a survival knife, a seclite, an explorer's suit, mesons, an automatic mining scanner, a mining satchel, a gas mask, a mining radio key and a special ID card with a basic mining access."

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -92,7 +92,7 @@
 
 // IRIS ADDITION START
 /datum/voucher_set/mining/minebot_kit/spawn_set(atom/spawn_loc)
-	if(GLOB.minebot_amount == 10)
+	if(GLOB.minebot_amount <= 10)
 		set_items -= /mob/living/basic/mining_drone
 	return ..()
 // IRIS ADDITION END

--- a/modular_iris/modules/mob/living/basic/minebots/minebot.dm
+++ b/modular_iris/modules/mob/living/basic/minebots/minebot.dm
@@ -1,14 +1,7 @@
-/mob/living/basic/mining_drone
-	var/static/living_limit = 0
-
 /mob/living/basic/mining_drone/Initialize(mapload)
 	. = ..()
-	living_limit++
-	if(living_limit > 10)
-		var/obj/item/card/mining_point_card/card = new(loc)
-		card.points = 438 // Roughly the cost of a minebot if ordered via shuttle
-		qdel(src)
+	GLOB.minebot_amount++
 
 /mob/living/basic/mining_drone/Destroy(force)
-	living_limit--
+	GLOB.minebot_amount--
 	return ..()

--- a/modular_iris/modules/mob/living/basic/minebots/minebot.dm
+++ b/modular_iris/modules/mob/living/basic/minebots/minebot.dm
@@ -6,7 +6,7 @@
 	living_limit++
 	if(living_limit > 10)
 		var/obj/item/card/mining_point_card/card = new(loc)
-		card.points = floor(675 / cargo_cost_multiplier)
+		card.points = 438 // Roughly the cost of a minebot if ordered via shuttle
 		qdel(src)
 
 /mob/living/basic/mining_drone/Destroy(force)

--- a/modular_iris/modules/mob/living/basic/minebots/minebot.dm
+++ b/modular_iris/modules/mob/living/basic/minebots/minebot.dm
@@ -1,0 +1,14 @@
+/mob/living/basic/mining_drone
+	var/static/living_limit = 0
+
+/mob/living/basic/mining_drone/Initialize(mapload)
+	. = ..()
+	living_limit++
+	if(living_limit > 10)
+		var/obj/item/card/mining_point_card/card = new(loc)
+		card.points = floor(675 / cargo_cost_multiplier)
+		qdel(src)
+
+/mob/living/basic/mining_drone/Destroy(force)
+	living_limit--
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6897,6 +6897,7 @@
 #include "modular_iris\modules\mining\mining_loot.dm"
 #include "modular_iris\modules\mining\ore_vents.dm"
 #include "modular_iris\modules\mob\dead\new_player\sprite_accessories.dm"
+#include "modular_iris\modules\mob\living\basic\minebots\minebot.dm"
 #include "modular_iris\modules\modular_vending\megaseed.dm"
 #include "modular_iris\modules\modular_vending\code\autodrobe.dm"
 #include "modular_iris\modules\modular_vending\code\clothing.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -523,6 +523,7 @@
 #include "code\__DEFINES\~~iris_defines\species_clothing_paths.dm"
 #include "code\__DEFINES\~~iris_defines\__HELPERS\global_lists.dm"
 #include "code\__DEFINES\~~iris_defines\_globalvars\cargo.dm"
+#include "code\__DEFINES\~~iris_defines\_globalvars\minebots.dm"
 #include "code\__DEFINES\~~iris_defines\dcs\signals\votes.dm"
 #include "code\__DEFINES\~~iris_defines\research\misc.dm"
 #include "code\__DEFINES\~~iris_defines\research\research_categories.dm"


### PR DESCRIPTION
## About The Pull Request

Makes it so minebots wont be purchasable if there would be more than 10

This is by no means anything that should be merged, its a temporary patch. The cost right now is still the same as if you were buying 9 mining bots even if your received count goes down to 1 since the `for()` loop is behind cost checking (why?)

Relevant issue: https://github.com/tgstation/tgstation/issues/91738

## Why it's Good for the Game

Apparently they are lagging the game so much in high amounts that its crashing, this prevents that in a quick way.

## Changelog

:cl:
fix: Made all minebots limited to 10 existing at a time.
/:cl:
