### PR TITLE
makes serenity armory less shit

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -10583,9 +10583,9 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "cZp" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/laser_gun,
 /obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "cZr" = (
@@ -43482,8 +43482,13 @@
 /area/station/security/prison)
 "mvZ" = (
 /obj/structure/rack,
-/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/temperature/security{
+	pixel_y = -5
+	},
 /obj/effect/turf_decal/bot,
+/obj/item/gun/energy/ionrifle{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "mwb" = (
@@ -57964,8 +57969,14 @@
 /area/station/maintenance/port/greater)
 "qPZ" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/armory/e_gun,
 /obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/armory/laser_gun{
+	pixel_y = -6
+	},
+/obj/effect/spawner/random/armory/laser_gun{
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/armory/laser_gun,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "qQh" = (
@@ -60372,8 +60383,14 @@
 /area/station/science/xenobiology)
 "rBG" = (
 /obj/structure/rack,
-/obj/effect/spawner/random/armory/disablers,
 /obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/armory/disablers{
+	pixel_y = -6
+	},
+/obj/effect/spawner/random/armory/disablers{
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/armory/disablers,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "rBH" = (
@@ -76007,9 +76024,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/lower)
 "waN" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
 /obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/smg,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "waW" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Serenity currently has quite possibly the worst armory in the rotation, this makes it less bad
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Old armory literally had less guns than the contraband locker which is hilarious
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
map diff bot should have a pic of it working
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: made serenity armory less bad
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
