### PR TITLE
The ACTUAL "Declassified" Modsuit Modules

### DIFF
--- a/code/__DEFINES/~~iris_defines/research/techweb_nodes.dm
+++ b/code/__DEFINES/~~iris_defines/research/techweb_nodes.dm
@@ -4,3 +4,5 @@
 
 #define TECHWEB_SEC_ADVANCED "advanced_sec"
 #define TECHWEB_NODE_BOTANY_ADV "botanygene"
+
+#define TECHWEB_NODE_MOD_DECLASSIFIED "mod_declassified"

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -91,7 +91,7 @@
 	icon_state = "storage_large"
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 60
-	max_items = 21
+	max_items = 30 /// IRIS EDIT: Changed to be the same as BoH considering it's admin-only and to be above the nerfed version
 	big_nesting = TRUE
 
 ///Ion Jetpack - Lets the user fly freely through space using battery charge.

--- a/modular_iris/modules/mod/modules.dm
+++ b/modular_iris/modules/mod/modules.dm
@@ -1,0 +1,35 @@
+
+/obj/item/mod/module/storage/bluespace/nerfed
+	icon_state = "storage_bluespace"
+	max_w_class = WEIGHT_CLASS_HUGE
+	max_combined_w_class = 30
+	max_items = 25
+	big_nesting = TRUE
+
+// Same as the Syndie version, but with has higher power drain, complexity and takes longer to charge. Also can't be used with armor modules.
+/obj/item/mod/module/energy_shield/nanotrasen
+	desc = "A prototype, previously classified by Nanotrasen's R&D, made to mimic the Syndicate's own Energy Shield Module. \
+		It is capable of blocking nearly any incoming attack, but only once every few seconds. \
+		Due to it's weird design, it can not be used alongside any retractable armor plates."
+	/// 2 more complexity.
+	complexity = 5
+	/// Double the power usage.
+	idle_power_cost = DEFAULT_CHARGE_DRAIN * 1
+	use_energy_cost = DEFAULT_CHARGE_DRAIN * 4
+	incompatible_modules = list(/obj/item/mod/module/energy_shield, /obj/item/mod/module/armor_booster)
+	/// 5 seconds longer delay.
+	recharge_start_delay = 15 SECONDS
+	/// Double the delay.
+	charge_increment_delay = 2 SECONDS
+	shield_icon = "shield-old"
+
+// Same as nukie version but has double the complexity and triple the power cost.
+/obj/item/mod/module/medbeam/nanotrasen
+	complexity = 2
+	active_power_cost = DEFAULT_CHARGE_DRAIN * 3
+	device = /obj/item/gun/medbeam/mod/nanotrasen
+	cooldown_time = 1
+
+// NT version with half the range.
+/obj/item/gun/medbeam/mod/nanotrasen
+	max_range = 4

--- a/modular_iris/modules/research/code/designs/misc_designs.dm
+++ b/modular_iris/modules/research/code/designs/misc_designs.dm
@@ -17,3 +17,38 @@
 	build_path = /obj/item/toy/crayon/spraycan/roboticist
 	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_TOOLS + RND_SUBCATEGORY_EQUIPMENT_SCIENCE)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/module/mod_storage_bluespace
+	name = "Bluespace Storage Module"
+	id = "mod_storage_bluespace"
+	materials = list(
+		/datum/material/gold =SHEET_MATERIAL_AMOUNT * 1.5,
+		/datum/material/diamond =SHEET_MATERIAL_AMOUNT * 1.5,
+		/datum/material/uranium = SHEET_MATERIAL_AMOUNT * 2.5,
+		/datum/material/bluespace =SHEET_MATERIAL_AMOUNT * 1.5,
+		)
+
+	build_path = /obj/item/mod/module/storage/bluespace/nerfed
+
+/datum/design/module/energy_shield/nanotrasen
+	name = "Energy Shield Module"
+	id = "mod_shield_nt"
+	materials = list(
+		/datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/gold =SHEET_MATERIAL_AMOUNT * 3.5,
+		/datum/material/plasma =SHEET_MATERIAL_AMOUNT * 3.5,
+		/datum/material/diamond =SHEET_MATERIAL_AMOUNT * 4,
+	)
+	build_path = /obj/item/mod/module/energy_shield/nanotrasen
+
+/datum/design/module/medbeam/nanotrasen
+	name = "Medical Beam Module"
+	id = "mod_medbeam_nt"
+	materials = list(
+		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3,
+		/datum/material/diamond = SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 3.5,
+	)
+	build_path = /obj/item/mod/module/medbeam/nanotrasen
+	category = list(RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL)

--- a/modular_iris/modules/research/code/techweb/all_nodes.dm
+++ b/modular_iris/modules/research/code/techweb/all_nodes.dm
@@ -44,3 +44,18 @@
 		"plantgene",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
+
+/datum/techweb_node/declassified_modules
+	id = TECHWEB_NODE_MOD_DECLASSIFIED
+	display_name = "Declassified Modular Suit"
+	description = "Modular Technology that was either reversed engineered or previously restricted to Nanotrasen's Higher-ups but later approved for normal research."
+	prereq_ids = list(TECHWEB_NODE_MOD_ANOMALY)
+	design_ids = list(
+		"mod_storage_bluespace",
+		"mod_shield_nt",
+		"mod_medbeam_nt",
+		)
+	required_items_to_unlock = list(/obj/item/mod/module/energy_shield/nanotrasen)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS * 2)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE)
+	hidden = TRUE

--- a/modular_nova/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nakamura_modsuits.dm
@@ -95,6 +95,12 @@
 	item_type = /obj/item/mod/module/armor_booster/retractplates
 	cost = PAYCHECK_COMMAND * 3
 
+// IRIS ADDITION START
+/datum/armament_entry/company_import/nakamura_modsuits/protection_modules/shield_nt
+	item_type = /obj/item/mod/module/energy_shield/nanotrasen
+	cost = PAYCHECK_COMMAND * 15
+// IRIS ADDITION END
+
 // Medical Mods
 
 /datum/armament_entry/company_import/nakamura_modsuits/medical_modules

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6913,6 +6913,7 @@
 #include "modular_iris\modules\mining\mining_loot.dm"
 #include "modular_iris\modules\mining\ore_vents.dm"
 #include "modular_iris\modules\mob\dead\new_player\sprite_accessories.dm"
+#include "modular_iris\modules\mod\modules.dm"
 #include "modular_iris\modules\modular_vending\megaseed.dm"
 #include "modular_iris\modules\modular_vending\code\autodrobe.dm"
 #include "modular_iris\modules\modular_vending\code\clothing.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I always wondered why we couldn't get Bluespace Storage modules. Why be stinky and restrict them to admin only? Well, this PR changes that.

Behold, a "nerfed" Bluespace Storage module for all your storage needs! It very similar to the Bag of Holding but has a max combined weight of 30 (BoH is 35) and can fit 5 less items. Also only fits items no bigger then huge. In other words, you can't store mech parts for example.

An Energy Shield module, similar to Nuke Ops but worse! It has 5 extra seconds of delay plus double the charge delay. So I guess it takes 17 seconds to fully charge. It's also blue and can't be used with armor modules!

A reverse engineered Medbeam module! It has double the complexity compared to the Syndie version, triple the power usage and half the range!

_Boy NT R&D sure can't reverse engineer stuff..._

"How do we get them?" you might be asking. Shrimple! Buy the energy module from cargo for only 1500 credits, shove it in the destructive analyzer, research "Declassified Modular Suit" and there you have it! All 3 modules ready for printing!
What, you didn't expect me to hand them on a silver platter, did you?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

is it supposed to be? :3

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Nanotrasen R&D has finally declassify Bluespace Storage Module, a bad Energy Shield Module and a Short Range Medbeam Module.
admin: Admin Bluespace Storage Module can hold 30 items instead of 21, more then BoH.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
