### PR TITLE
Adds transformative wintercoats, the wintercoats that change with your job

### DIFF
--- a/modular_iris/master_files/code/modules/clothing/suits/special.dm
+++ b/modular_iris/master_files/code/modules/clothing/suits/special.dm
@@ -1,0 +1,53 @@
+// Whilst we are technically not clothes, we should turn fast enough for players to never notice
+/obj/item/transformative_wintercoat
+	name = "Transformative Wintercoat"
+	desc = "A special type of wintercoat that uses nanobots to quickly change its shape into the assigned job of the wearer, its limited amount of nanobots means it cannot replicate more exotic wintercoats."
+	icon = 'icons/obj/clothing/suits/wintercoat.dmi'
+	icon_state = "coatwinter"
+	var/changing = FALSE
+
+/obj/item/transformative_wintercoat/equipped(mob/user, slot, initial = FALSE)
+	. = ..()
+	if(!changing) // sanity check for race conditions (as if)
+		changing = TRUE
+		INVOKE_ASYNC(src, PROC_REF(change_wintercoat), user) // Me when coders forbid me from overriding on_equipped()
+
+/obj/item/transformative_wintercoat/proc/change_wintercoat(mob/user)
+	var/turf/our_turf = get_turf(src)
+	moveToNullspace()
+	sleep(1)
+	if(QDELETED(src) || isnull(user.mind))
+		return
+	var/list/wintercoat_list = list(
+		// Just a note, command is left out as their coats are unique and shouldn't be this easy to produce
+		// Service
+		/datum/job/botanist = /obj/item/clothing/suit/hooded/wintercoat/hydro,
+		/datum/job/janitor = /obj/item/clothing/suit/hooded/wintercoat/janitor,
+		/datum/job/bartender = /obj/item/clothing/suit/hooded/wintercoat/nova/bartender,
+		// Security
+		/datum/job_department/security = /obj/item/clothing/suit/hooded/wintercoat/security,
+		// Medical
+		/datum/job_department/medical = /obj/item/clothing/suit/hooded/wintercoat/medical,
+		/datum/job/chemist = /obj/item/clothing/suit/hooded/wintercoat/medical/chemistry,
+		/datum/job/coroner = /obj/item/clothing/suit/hooded/wintercoat/medical/coroner,
+		/datum/job/virologist = /obj/item/clothing/suit/hooded/wintercoat/medical/viro,
+		/datum/job/paramedic = /obj/item/clothing/suit/hooded/wintercoat/medical/paramedic,
+		// Science
+		/datum/job_department/science = /obj/item/clothing/suit/hooded/wintercoat/science,
+		/datum/job/roboticist = /obj/item/clothing/suit/hooded/wintercoat/science/robotics,
+		/datum/job/geneticist = /obj/item/clothing/suit/hooded/wintercoat/science/genetics,
+		// Engineering
+		/datum/job_department/engineering = /obj/item/clothing/suit/hooded/wintercoat/engineering,
+		/datum/job/atmospheric_technician = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos,
+		// Cargo
+		/datum/job_department/cargo = /obj/item/clothing/suit/hooded/wintercoat/cargo,
+		/datum/job/shaft_miner = /obj/item/clothing/suit/hooded/wintercoat/miner,
+	)
+	var/datum/job/role = user.mind.assigned_role
+	var/obj/item/clothing/suit/hooded/wintercoat/wintercoat = wintercoat_list[role.type] || wintercoat_list[role.departments_list?[1]]
+	if(isnull(wintercoat))
+		wintercoat = /obj/item/clothing/suit/hooded/wintercoat
+
+	wintercoat = new wintercoat(our_turf)
+	user.put_in_active_hand(wintercoat)
+	qdel(src)

--- a/modular_iris/modules/loadouts/loadout_items/iris_loadout_datum_suit.dm
+++ b/modular_iris/modules/loadouts/loadout_items/iris_loadout_datum_suit.dm
@@ -12,6 +12,10 @@
 	name = "Paramedic's Jacket"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/paramedic
 
+/datum/loadout_item/suit/transform_wintercoat
+	name = "Transformative Wintercoat (briefcase-only)"
+	item_path = /obj/item/transformative_wintercoat
+
 // NABBER ITEMS
 /datum/loadout_item/suit/nabberponcho
 	name = "Giant Poncho"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6831,6 +6831,7 @@
 #include "modular_iris\master_files\code\modules\client\preferences\mapvote_hud.dm"
 #include "modular_iris\master_files\code\modules\client\preferences\say_prefs.dm"
 #include "modular_iris\master_files\code\modules\clothing\gloves\special.dm"
+#include "modular_iris\master_files\code\modules\clothing\suits\special.dm"
 #include "modular_iris\master_files\code\modules\job\job_types\_job.dm"
 #include "modular_iris\master_files\code\modules\mob\living\blood_types.dm"
 #include "modular_iris\master_files\code\modules\mob\living\carbon\human\butts.dm"


### PR DESCRIPTION

## About The Pull Request

Now available at your local loadout shop, a wintercoat that changes when you take it into your hand depending on what job you landed.
No longer fear having the engineering wintercoat whilst playing as a doctor and having to walk 5 feet to the left to get a medical one from the vendor. The future is now!

## Why it's Good for the Game

I think its just convinient to have an option of a job wintercoat instead of a specific one when you spawn, think of it like the "departmental satchel" option in backpacks

## Changelog

:cl:
add: Added a new wintercoat that transforms upon touching it into whatever variant that your job currently has
/:cl:
