### PR TITLE
Reverts psyker PR from upstream

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -11,8 +11,6 @@
 	var/fade_out_time = 0.3 SECONDS
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
 	var/images_are_static = TRUE
-	/// Does this echolocation cause us to go blind?
-	var/blinding = TRUE
 	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.
 	var/echo_group = null
 	/// This trait blocks us from receiving echolocation.
@@ -34,7 +32,7 @@
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, blinding, use_echo = TRUE, show_own_outline = FALSE) // NOVA EDIT CHANGE - ORIGINAL: /datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, blinding)
+/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path, use_echo = TRUE, show_own_outline = FALSE) // NOVA EDIT CHANGE - ORIGINAL: /datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))
@@ -53,8 +51,6 @@
 		src.fade_in_time = fade_in_time
 	if(!isnull(fade_out_time))
 		src.fade_out_time = fade_out_time
-	if(!isnull(blinding))
-		src.blinding = blinding
 	if(!isnull(images_are_static))
 		src.images_are_static = images_are_static
 	if(!isnull(blocking_trait))
@@ -67,11 +63,11 @@
 	if(ispath(color_path))
 		client_colour = echolocator.add_client_colour(color_path, src.echo_group)
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), src.echo_group) //so they see all the tiles they echolocated, even if they are in the dark
-	if(blinding)
-		echolocator.become_blind(ECHOLOCATION_TRAIT)
-		if (use_echo) // NOVA EDIT ADDITION - add constructor toggle to not use the eye overlay
-			echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon) // NOVA EDIT CHANGE - No change except indented one tab
+	echolocator.become_blind(ECHOLOCATION_TRAIT)
+	// NOVA EDIT ADDITION START
+	if (use_echo) // add constructor toggle to not use the eye overlay
 		echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo, echo_icon)
+	// NOVA EDIT ADDITION END
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/echolocation/Destroy(force)
@@ -79,9 +75,8 @@
 	var/mob/living/echolocator = parent
 	QDEL_NULL(client_colour)
 	echolocator.remove_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_TRUE_NIGHT_VISION), echo_group)
-	if(blinding)
-		echolocator.cure_blind(ECHOLOCATION_TRAIT)
-		echolocator.clear_fullscreen("echo")
+	echolocator.cure_blind(ECHOLOCATION_TRAIT)
+	echolocator.clear_fullscreen("echo")
 	for(var/mob/living/echolocate_receiver as anything in receivers)
 		if(!echolocate_receiver.client)
 			continue
@@ -106,19 +101,11 @@
 		real_echo_range += 2
 	var/list/filtered = list()
 	var/list/seen = dview(real_echo_range, get_turf(echolocator.client?.eye || echolocator), invis_flags = echolocator.see_invisible)
-	if(blinding)
-		for(var/atom/seen_atom as anything in seen)
-			if(!seen_atom.alpha)
-				continue
-			if(allowed_paths[seen_atom.type])
-				filtered += seen_atom
-	else
-		var/list/ranged_atoms = range(real_echo_range, get_turf(echolocator.client?.eye || echolocator))
-		for(var/atom/possible_atom as anything in ranged_atoms)
-			if(!possible_atom.alpha)
-				continue
-			if(allowed_paths[possible_atom.type])
-				filtered += possible_atom
+	for(var/atom/seen_atom as anything in seen)
+		if(!seen_atom.alpha)
+			continue
+		if(allowed_paths[seen_atom.type])
+			filtered += seen_atom
 	if(!length(filtered))
 		return
 	var/current_time = "[world.time]"
@@ -133,7 +120,7 @@
 
 /datum/component/echolocation/proc/show_image(image/input_appearance, atom/input, current_time)
 	var/image/final_image = image(input_appearance)
-	//final_image.layer += FOV_EFFECT_LAYER
+	final_image.layer += EFFECTS_LAYER
 	final_image.plane = FULLSCREEN_PLANE
 	final_image.loc = images_are_static ? get_turf(input) : input
 	final_image.dir = input.dir
@@ -214,3 +201,45 @@
 /atom/movable/screen/fullscreen/echo/Destroy()
 	QDEL_NULL(particles)
 	return ..()
+
+//IRIS EDIT ADDITION BEGIN - SLOWER_ECHOLOCATION_PREF
+/// Used to change delay between echolation auto-pulses, measured in seconds
+/datum/preference/numeric/echolocation_speed
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "echolocation_speed"
+	savefile_identifier = PREFERENCE_CHARACTER
+	minimum = 1
+	maximum = 15
+
+/datum/preference/numeric/echolocation_speed/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Echolocation" in preferences.all_quirks
+
+/datum/preference/numeric/echolocation_speed/create_default_value()
+	return 5
+
+/datum/preference/numeric/echolocation_speed/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/// Used to stretch fadein, presence and fadeout times of each echolocation image
+/datum/preference/numeric/echolocation_mult
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "echolocation_mult"
+	savefile_identifier = PREFERENCE_CHARACTER
+	minimum = 1
+	maximum = 15
+
+/datum/preference/numeric/echolocation_mult/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Echolocation" in preferences.all_quirks
+
+/datum/preference/numeric/echolocation_mult/create_default_value()
+	return 1
+
+/datum/preference/numeric/echolocation_mult/apply_to_human(mob/living/carbon/human/target, value)
+	return
+//IRIS EDIT ADDITION END

--- a/modular_nova/modules/echolocation_quirk/code/echolocation.dm
+++ b/modular_nova/modules/echolocation_quirk/code/echolocation.dm
@@ -39,7 +39,7 @@
 	//IRIS EDIT ADDITION END
 
 	//IRIS EDIT CHANGE BEGIN - SLOWER_ECHOLOCATION_PREF
-	human_holder.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DEAF, echo_range = 5, echo_group = client_echo_group, images_are_static = FALSE, blinding = TRUE, use_echo = client_use_echo, show_own_outline = TRUE, cooldown_time = client_echo_speed)
+	human_holder.AddComponent(/datum/component/echolocation, blocking_trait = TRAIT_DEAF, echo_range = 5, echo_group = client_echo_group, images_are_static = FALSE, use_echo = client_use_echo, show_own_outline = TRUE, cooldown_time = client_echo_speed)
 	//IRIS EDIT CHANGE END
 	esp = human_holder.GetComponent(/datum/component/echolocation)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Echolocation got sharted cause TG changed how the component worked upstream.

## Why it's Good for the Game

People want the quirk they selected to actually work.
## Proof of Testing

<img width="1010" height="766" alt="image" src="https://github.com/user-attachments/assets/89a7be95-52c0-4f97-ad33-9b2ce097662c" />

## Changelog

:cl:
del: reverted psyker pr
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
