### PR TITLE
Changes paperwork implant to 0

### DIFF
--- a/modular_nova/modules/customization/modules/client/augment/implants.dm
+++ b/modular_nova/modules/customization/modules/client/augment/implants.dm
@@ -45,7 +45,7 @@
 
 /datum/augment_item/implant/l_arm/bureaucracy
 	name = "Left Bureaucrat's 'Jacent' Toolset Implant (4-colour Pen + Small Paper Bin + Approve/Deny Stamps)"
-	cost = 4
+	cost = 0 // IRIS EDIT - it's pens
 	path = /obj/item/organ/cyberimp/arm/toolkit/bureaucracy/left_arm
 
 /datum/augment_item/implant/l_arm/cargo
@@ -108,7 +108,7 @@
 
 /datum/augment_item/implant/r_arm/bureaucracy
 	name = "Right Bureaucrat's 'Jacent' Toolset Implant (4-colour Pen + Small Paper Bin + Approve/Deny Stamps)"
-	cost = 4
+	cost = 0 // IRIS EDIT - it's pens
 	path = /obj/item/organ/cyberimp/arm/toolkit/bureaucracy/right_arm
 
 /datum/augment_item/implant/r_arm/cargo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What the title says. Makes the paperwork implant cost nothing.

## Why it's Good for the Game

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

It's a Pen.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<img width="640" height="91" alt="image" src="https://github.com/user-attachments/assets/64a2299c-1a36-4b3b-8105-aa52f71a6b96" />


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
tweak: paperwork implant in augments cost 0 points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
