### PR TITLE
Disables the "Human AI" Station Trait

### DIFF
--- a/code/datums/station_traits/job_traits.dm
+++ b/code/datums/station_traits/job_traits.dm
@@ -183,7 +183,7 @@
 /datum/station_trait/job/human_ai
 	name = "Human AI"
 	button_desc = "Sign up to become the \"AI\"."
-	weight = 1
+	weight = 0 //IRIS ADDITION: Well, removal. Disabling this!
 	trait_flags = parent_type::trait_flags | STATION_TRAIT_REQUIRES_AI
 	report_message = "Our recent technological advancements in machine Artificial Intelligence has proven futile. In the meantime, we're sending an Intern to help out."
 	show_in_report = TRUE


### PR DESCRIPTION
## About The Pull Request
Just makes a 1 a 0, disabling the station trait from rolling to spare AI mains the pain.

## Why it's Good for the Game

This trait adds nothing to the game as is, beyond an annoyance to AI players who ready up and suddenly get smacked with playing a humanoid, with janky mechanics and controls to try and do their job. It's, at least for me, incredibly unfun and just boring. 

## Proof of Testing
<img width="612" height="236" alt="image" src="https://github.com/user-attachments/assets/7c65fe67-efbf-4ba8-9637-fec725478cef" />

One line change, so. Uh.

## Changelog

:cl:
del: Banishes the Human-Station-AI trait from ever appearing again.
/:cl:

