### PR TITLE
Allows NIF users to use neuroware

### DIFF
--- a/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
+++ b/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
@@ -22,8 +22,9 @@
 			// SYNTHETIC-oriented neuroware can't affect organic brains
 			if(reagent.chemical_flags & REAGENT_NEUROWARE)
 				var/obj/item/organ/brain/owner_brain = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN)
+				var/obj/item/organ/cyberimp/brain/nif/is_nif_user = human_processor.get_organ_by_type(/obj/item/organ/cyberimp/brain/nif)
 				// Neuroware always metabolizes in synthetic brains regardless of liver, but never metabolizes in organic brains
-				if(owner_brain.organ_flags & ORGAN_ROBOTIC)
+				if(owner_brain.organ_flags & ORGAN_ROBOTIC || is_nif_user)
 					return TRUE
 				else
 					return FALSE

--- a/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
+++ b/modular_nova/modules/liquids/code/reagents/chemistry/holder.dm
@@ -19,7 +19,7 @@
 
 		// SYNTHETIC-oriented reagents require PROCESS_SYNTHETIC or a synth liver
 		if((reagent.process_flags & REAGENT_SYNTHETIC))
-			// SYNTHETIC-oriented neuroware can't affect organic brains
+			// SYNTHETIC-oriented neuroware can't affect organic brains, unless they have a nif
 			if(reagent.chemical_flags & REAGENT_NEUROWARE)
 				var/obj/item/organ/brain/owner_brain = human_processor.get_organ_slot(ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/cyberimp/brain/nif/is_nif_user = human_processor.get_organ_by_type(/obj/item/organ/cyberimp/brain/nif)

--- a/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
+++ b/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
@@ -120,7 +120,7 @@
 			return TRUE
 	return FALSE
 
-///Installs only if the mob has a synthetic brain
+///Installs only if the mob has a synthetic brain, unless they got a nif
 /obj/item/disk/neuroware/proc/try_install(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(!ishuman(target))
 		return

--- a/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
+++ b/modular_nova/modules/neuroware/code/objects/items/_neuroware.dm
@@ -128,7 +128,8 @@
 		balloon_alert(user, "it's been used up!")
 		return
 	var/obj/item/organ/brain/owner_brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(isnull(owner_brain) || !(owner_brain.organ_flags & ORGAN_ROBOTIC))
+	var/obj/item/organ/cyberimp/brain/nif/is_nif_user = target.get_organ_by_type(/obj/item/organ/cyberimp/brain/nif)
+	if(isnull(owner_brain) || !(owner_brain.organ_flags & ORGAN_ROBOTIC || is_nif_user))
 		balloon_alert(user, "synthetic brain required!")
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a missing feature that was mentioned in the pr below
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
This was supposed to be a feature as stated in

- https://github.com/NovaSector/NovaSector/pull/4503

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
tried without a nif and it didnt work, works fine with it though, synths work fine as well
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: nif users can use neuroware
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
