### PR TITLE
Allows plasmamen to set their eye colour

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
@@ -9,7 +9,7 @@
 	dmg_overlay_type = null
 	brute_modifier = 1 //Plasmemes are BONE!!! IRIS EDIT - changes 1.5 to 1
 	burn_modifier = 1.15 //Plasmemes are FLAMMABLE!!! IRIS EDIT - changes 1.5 to 1.15
-	head_flags = HEAD_EYESPRITES
+	head_flags = HEAD_EYESPRITES|HEAD_EYECOLOR //IRIS EDIT - lets plasmamen set their eye color instead of it being blindingly white
 	bodypart_flags = BODYPART_UNHUSKABLE
 	bodypart_effects = list(/datum/status_effect/grouped/bodypart_effect/plasma_based)
 


### PR DESCRIPTION
## About The Pull Request
Just gives players the option to set an eye color for plasmamen, shouldn't touch anything else!

## Why it's Good for the Game
I was mildly annoyed that for some reason plasmamen had their eyes set to be pure white and more options are always nice.

## Proof of Testing
<img width="773" height="300" alt="image" src="https://github.com/user-attachments/assets/ad2ed25e-5c99-41d7-aaad-83db97d4983a" />

Just a one line change.

<img width="610" height="243" alt="image" src="https://github.com/user-attachments/assets/2ec51537-b1ac-49fd-a6e9-c7fe8b441d35" />

Upsettingly blue-eyed. In the preview if you have clothes on it'll show them as having yellow eyes thanks to. That being how plasma-man helmets are sprited.

## Changelog


:cl:
add: Adds a single flag to the plasma-man head, allowing them to now set their eye colour.
/:cl:

