### PR TITLE
Gives beanies cold protection

### DIFF
--- a/code/modules/clothing/head/beanie.dm
+++ b/code/modules/clothing/head/beanie.dm
@@ -15,6 +15,10 @@
 	greyscale_config_worn = /datum/greyscale_config/beanie/worn
 	greyscale_colors = "#EEEEEE#EEEEEE"
 	flags_1 = IS_PLAYER_COLORABLE_1
+// IRIS EDIT START, adds cold protection
+	cold_protection = HEAD
+	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+// IRIS EDIT END
 
 /obj/item/clothing/head/beanie/black
 	name = "black beanie"
@@ -59,6 +63,10 @@
 	icon = 'icons/obj/clothing/head/beanie.dmi'
 	worn_icon = 'icons/mob/clothing/head/beanie.dmi'
 	icon_state = "beanierasta"
+// IRIS EDIT START, adds cold protection
+	cold_protection = HEAD
+	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+// IRIS EDIT END
 
 /obj/item/clothing/head/waldo
 	name = "red striped bobble hat"
@@ -66,6 +74,10 @@
 	icon = 'icons/obj/clothing/head/beanie.dmi'
 	worn_icon = 'icons/mob/clothing/head/beanie.dmi'
 	icon_state = "waldo_hat"
+// IRIS EDIT START, adds cold protection
+	cold_protection = HEAD
+	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+// IRIS EDIT END
 
 //No dog fashion sprites yet :(  poor Ian can't be dope like the rest of us yet
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It gives beanies cold protection, also the rastacaps and bobblehat that I noticed were in the same file but weren't subtypes

## Why it's Good for the Game

i think it makes sense, and there's only a handful of actually cold-protecting headwear items for some reason

## Proof of Testing

<img width="551" height="87" alt="dreamseeker_zygNdeuonO" src="https://github.com/user-attachments/assets/ae4c5436-e4e1-4e92-a437-a9181af3cba1" />

## Changelog

:cl:
balance: Gave beanies cold protection (beanies and subtypes, rastacaps, bobblehats)
/:cl:
