### PR TITLE
reverts #513 and #497

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/mob_spawn.dm
@@ -48,10 +48,7 @@
 			SSquirks.AssignQuirks(spawned_human, spawned_human.client)
 
 		post_transfer_prefs(spawned_human)
-// IRIS ADDITION START
-		if (istype(spawned_human, /mob/living/carbon/human))
-			spawned_human.grant_language(/datum/language/common, source = LANGUAGE_SPAWNER)
-// IRIS ADDITION END
+
 	if(load_prefs && loadout_enabled)
 		spawned_human?.equip_outfit_and_loadout(outfit, spawned_mob.client.prefs)
 	else if (!isnull(spawned_human))
@@ -69,10 +66,7 @@
 	var/mob/living/spawned_mob = new mob_type(get_turf(src)) //living mobs only
 	name_mob(spawned_mob, newname)
 	special(spawned_mob, mob_possessor)
-// IRIS ADDITION START
-	if(!istype(src, /obj/effect/mob_spawn/ghost_role))
-		equip(spawned_mob)
-// IRIS ADDITION END
+	equip(spawned_mob)
 	return spawned_mob
 
 // Anything that can potentially be overwritten by transferring prefs must go in this proc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts these pr's because ghost roles keep spawning naked because of them

- #513 
- #497 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
I would rather have functional ghost roles than not having duplicate items
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ghost roles will no longer spawn in naked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
