### PR TITLE
Revert "Makes ice wastes atmos breathable"

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -47,7 +47,7 @@
 /// The maximum temperature of Lavaland
 #define LAVALAND_MAX_TEMPERATURE 350
 /// The minimum temperature of Icebox
-#define ICEBOX_MIN_TEMPERATURE 261 //IRIS EDIT was 180
+#define ICEBOX_MIN_TEMPERATURE 180
 
 /// The natural temperature for a body
 #define BODYTEMP_NORMAL 310.15

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -29,26 +29,22 @@
 	id = ICEMOON_DEFAULT_ATMOS
 
 	base_gases = list(
-		/datum/gas/oxygen=30, //IRIS EDIT so ppl won't suffocate, was 5
+		/datum/gas/oxygen=5,
 		/datum/gas/nitrogen=10,
 	)
 	normal_gases = list(
 		/datum/gas/oxygen=10,
 		/datum/gas/nitrogen=10,
-		/datum/gas/carbon_dioxide=0, //IRIS EDIT was 10
+		/datum/gas/carbon_dioxide=10,
 	)
 	restricted_gases = list(
 		/datum/gas/plasma=0.1,
 		/datum/gas/water_vapor=0.1,
 		/datum/gas/miasma=1.2,
-		/datum/gas/plasma=0,
-		/datum/gas/water_vapor=0, //they all still somehow appear despite nova turning them off lol
-		/datum/gas/miasma=0,
 	)
 	restricted_chance = 0	// NOVA EDIT: Disables restricted gases from rolling - Original value (20)
 
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
-	minimum_pressure = HAZARD_LOW_PRESSURE + 20 //was 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
 	minimum_temp = ICEBOX_MIN_TEMPERATURE

--- a/code/modules/mob/living/basic/pets/penguin/penguin.dm
+++ b/code/modules/mob/living/basic/pets/penguin/penguin.dm
@@ -166,12 +166,10 @@
 /mob/living/basic/pet/penguin/baby/permanent
 	can_grow_up = FALSE
 
-//IRIS EDIT START
 /mob/living/basic/pet/penguin/emperor/snowdin
-	minimum_survivable_temperature = 180
+	minimum_survivable_temperature = ICEBOX_MIN_TEMPERATURE
 	gold_core_spawnable = NO_SPAWN
 
 /mob/living/basic/pet/penguin/baby/permanent/snowdin
-	minimum_survivable_temperature = 180
+	minimum_survivable_temperature = ICEBOX_MIN_TEMPERATURE
 	gold_core_spawnable = NO_SPAWN
-//IRIS EDIT END


### PR DESCRIPTION
Reverts IrisSS13/IrisStation#264

While this WAS a good idea on paper all it does is make the supermatter explode all the time because -10c is too hot for it, hull breaches should be more dangerous too.

<img width="1118" height="810" alt="boomer" src="https://github.com/user-attachments/assets/096ee7cd-6591-42f2-acd0-149e4ae11746" />
