### PR TITLE
Social Anxiety customizable text block chance

### DIFF
--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -11,10 +11,27 @@
 	mail_goodies = list(/obj/item/storage/pill_bottle/psicodine)
 	var/dumb_thing = TRUE
 
+	var/speech_block_chance = 50 // IRIS ADDITION, self explanatory
+
+// IRIS ADDITION START
+/datum/quirk_constant_data/social_anxiety
+	associated_typepath = /datum/quirk/social_anxiety
+	customization_options = list(/datum/preference/numeric/social_anxiety)
+// IRIS ADDITION END
+
 /datum/quirk/social_anxiety/add(client/client_source)
 	RegisterSignal(quirk_holder, COMSIG_MOB_EYECONTACT, PROC_REF(eye_contact))
 	RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINATE, PROC_REF(looks_at_floor))
 	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+	// IRIS ADDITION START
+	var/stutter_speech_pref = client_source?.prefs.read_preference(/datum/preference/numeric/social_anxiety)
+	if(!isnull(stutter_speech_pref))
+		speech_block_chance = stutter_speech_pref
+	else
+		speech_block_chance = 50
+	// IRIS ADDITION END
+
 	quirk_holder.apply_status_effect(/datum/status_effect/speech/stutter/anxiety, INFINITY)
 
 /datum/quirk/social_anxiety/remove()
@@ -59,7 +76,7 @@
 			new_message += word
 		message = jointext(new_message, " ")
 
-	if(prob(min(50, (0.50 * moodmod)))) //Max 50% chance of not talking
+	if(prob(speech_block_chance)) //IRIS EDIT Original "if(prob(min(50, (0.50 * moodmod))))" | Applies block chance based on preference
 		if(dumb_thing)
 			to_chat(quirk_holder, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
 			dumb_thing = FALSE //only once per life

--- a/modular_iris/master_files/code/modules/client/preferences/quirks/social_anxiety.dm
+++ b/modular_iris/master_files/code/modules/client/preferences/quirks/social_anxiety.dm
@@ -1,0 +1,15 @@
+/datum/preference/numeric/social_anxiety
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "social_anxiety"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+	step = 1
+
+	minimum = 0
+	maximum = 100 // why would anyone want it at 100, might as well take mute
+
+/datum/preference/numeric/social_anxiety/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+
+/datum/preference/numeric/social_anxiety/create_default_value()
+	return 50

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6839,6 +6839,7 @@
 #include "modular_iris\master_files\code\modules\client\preferences\footprint_sprite.dm"
 #include "modular_iris\master_files\code\modules\client\preferences\mapvote_hud.dm"
 #include "modular_iris\master_files\code\modules\client\preferences\say_prefs.dm"
+#include "modular_iris\master_files\code\modules\client\preferences\quirks\social_anxiety.dm"
 #include "modular_iris\master_files\code\modules\clothing\gloves\special.dm"
 #include "modular_iris\master_files\code\modules\clothing\suits\special.dm"
 #include "modular_iris\master_files\code\modules\job\job_types\_job.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/iris/social_anxiety.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/iris/social_anxiety.tsx
@@ -1,0 +1,6 @@
+import { Feature, FeatureNumberInput } from '../../base';
+
+export const social_anxiety: Feature<number> = {
+  name: 'Block Speech Chance',
+  component: FeatureNumberInput,
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now set a custom chance to not talk when using the social anxiety quirk.
Why? I always found it annoying that the game would just eat your sentence. This is my fix for it. It works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

Lets people control how often their text gets blocked with the quirk.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

This is 0% chance:
<img width="384" height="270" alt="Screenshot_6" src="https://github.com/user-attachments/assets/cb9bbcbf-894a-4af9-b45e-5a2cd0749435" />
This is 100% chance _why would someone even want this_:
<img width="518" height="177" alt="Screenshot_7" src="https://github.com/user-attachments/assets/ec209e42-09d9-4319-964f-affb150155b9" />


<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added ability to change the chance of having your text blocked with the Social Anxiety quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
