### PR TITLE
Gives Moths Teeth. (along with other previously toothless species)

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -104,4 +104,4 @@
 	icon_state = "lustrous_head"
 	limb_id = SPECIES_ETHEREAL_LUSTROUS
 	head_flags = NONE
-	teeth_count = 0 // bro you seen these thinsg. they got a crystal for a head aint no teeth here
+	teeth_count = 32 // bro you seen these thinsg. they got a crystal for a head aint no teeth here IRIS EDIT: They do now.

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -485,7 +485,7 @@
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
 	head_flags = NONE
-	// too hard to drill through
+	// too hard to drill through IRIS EDIT: You wish
 	teeth_count = 32
 
 /obj/item/bodypart/head/golem/Initialize(mapload)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -5,7 +5,7 @@
 	burn_modifier = 2
 	head_flags = HEAD_EYESPRITES|HEAD_DEBRAIN
 	biological_state = (BIO_FLESH|BIO_BLOODED)
-	teeth_count = 0
+	teeth_count = 32
 
 /obj/item/bodypart/chest/snail
 	limb_id = SPECIES_SNAIL
@@ -148,7 +148,7 @@
 ///LUMINESCENT
 /obj/item/bodypart/head/jelly/luminescent
 	limb_id = SPECIES_LUMINESCENT
-	teeth_count = 0
+	teeth_count = 32
 
 /obj/item/bodypart/chest/jelly/luminescent
 	limb_id = SPECIES_LUMINESCENT
@@ -271,7 +271,7 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_EYESPRITES|HEAD_EYEHOLES|HEAD_DEBRAIN // NOVA EDIT - Flies deserve hair - ORIGINAL: head_flags = HEAD_EYESPRITES|HEAD_EYEHOLES|HEAD_DEBRAIN
-	teeth_count = 0
+	teeth_count = 32
 	bodypart_traits = list(TRAIT_ANTENNAE)
 
 /obj/item/bodypart/chest/fly
@@ -415,7 +415,7 @@
 	is_dimorphic = TRUE
 	burn_modifier = 1.25
 	head_flags = NONE
-	teeth_count = 0
+	teeth_count = 32
 
 /obj/item/bodypart/chest/mushroom
 	limb_id = SPECIES_MUSHROOM
@@ -486,7 +486,7 @@
 	dmg_overlay_type = null
 	head_flags = NONE
 	// too hard to drill through
-	teeth_count = 0
+	teeth_count = 32
 
 /obj/item/bodypart/head/golem/Initialize(mapload)
 	worn_ears_offset = new(

--- a/modular_nova/modules/bodyparts/code/moth_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/moth_bodyparts.dm
@@ -5,7 +5,7 @@
 	limb_id = SPECIES_MOTH
 	is_dimorphic = TRUE
 	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_LIPS|HEAD_EYESPRITES|HEAD_EYEHOLES|HEAD_DEBRAIN //what the fuck, moths have lips?
-	teeth_count = 0
+	teeth_count = 32 //IRIS EDIT: Gives moth teeth. TREMBLE IN FEAR!!
 	bodypart_traits = list(TRAIT_ANTENNAE)
 
 /obj/item/bodypart/chest/moth

--- a/modular_nova/modules/bodyparts/code/roundstartslime_bodyparts.dm
+++ b/modular_nova/modules/bodyparts/code/roundstartslime_bodyparts.dm
@@ -9,7 +9,7 @@
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
-	teeth_count = 0
+	teeth_count = 32 // IRIS EDIT: GIves slime teeth
 	burn_modifier = 0.8
 
 /obj/item/bodypart/chest/jelly/slime/roundstart


### PR DESCRIPTION
Or, I made a spite pr because some guy on tg nerfed moths for no real reason.

## About The Pull Request
So, in [this](https://github.com/tgstation/tgstation/pull/83831) pr, a limit to pills you can implant via Dental Implant. My main gripe with it is that it makes it so moths can't get it for little reason. This simply changes it and gives the ability for some other species to have it too, like ethereal, flypeople, and golems. Abductors are excluded, but could be changed easily.
<img width="298" height="299" alt="337982944-97321eae-b592-4aef-a482-83694ef71078" src="https://github.com/user-attachments/assets/bd271bbc-c80d-491f-a823-6fb35d8017d7" />
Look at that smile! He's so happy to have teeth!
## Why it's Good for the Game

I really don't see why we should lock out playable species from this just because it's "unrealistic". You can rationalize giving them teeth as an mandible implant or something.

## Proof of Testing

<img width="493" height="118" alt="Code_05Mwt6LK0h" src="https://github.com/user-attachments/assets/01e9d669-979f-46ce-ad03-ab95144c1473" />

## Changelog

:cl:
balance: Moths and flypeople HAVE teeth. They CAN get dental implants. I'm BUFFING moths.
balance: Golems and Ethereal get teeth too
/:cl:

