### PR TITLE
Ghosts can always see flavor text regardless if they're wearing a mask or not

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -78,9 +78,10 @@
 		ooc_notes += preferences.read_preference(/datum/preference/text/ooc_notes)
 		headshot += preferences.read_preference(/datum/preference/text/headshot/silicon)
 
+// IRIS EDIT: Ghosts can see flavor text regardless of if it's obscured
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
-		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))
+		obscured = ((holder_human.wear_mask?.flags_inv & HIDEFACE) || (holder_human.head?.flags_inv & HIDEFACE)) && !isobserver(user)
 		custom_species = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.name : holder_human.dna.features["custom_species"]
 		flavor_text = obscured ? "Obscured" : holder_human.dna.features[EXAMINE_DNA_FLAVOR_TEXT]
 		custom_species_lore = obscured ? "Obscured" : holder_human.dna.species.lore_protected ? holder_human.dna.species.get_species_lore().Join("\n") : holder_human.dna.features["custom_species_lore"]


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. Due to limitations you can't see it without opening the window.

## Why it's Good for the Game
Makes it slightly easier to catch bad or lazy flavor texts.

## Proof of Testing
Before
<img width="1173" height="718" alt="dreamseeker_tLWvKg9Hs3" src="https://github.com/user-attachments/assets/b1362af2-2a3d-4c8d-935d-708dce1c5b34" />

After

<img width="1234" height="684" alt="dreamseeker_Pg71GjM1p8" src="https://github.com/user-attachments/assets/2b1904ef-ce67-462d-82bc-f844c666ddc5" />

## Changelog

:cl:
qol: Ghosts can see flavor text regardless of masks obscuring their face
/:cl:

