### PR TITLE
Reverts revival text back to tg one

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -381,7 +381,7 @@
 	var/client_like = client || HAS_TRAIT(src, TRAIT_MIND_TEMPORARILY_GONE)
 	var/valid_ghost = ghost?.can_reenter_corpse && ghost?.client
 	var/valid_soul = brain || !HAS_TRAIT(src, TRAIT_FAKE_SOULLESS)
-	if((brain && client_like) || (valid_ghost && valid_soul))
+	if((brain && client_like) || (valid_ghost && valid_soul) && (!HAS_TRAIT(src, TRAIT_DNR))) //IRIS EDIT: CHECK FOR DNR QUIRK, was: if((brain && client_like) || (valid_ghost && valid_soul))
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life...")
 	return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and [t_his] soul has departed...")
 

--- a/modular_nova/master_files/code/modules/mob/living/carbon/human_helpers.dm
+++ b/modular_nova/master_files/code/modules/mob/living/carbon/human_helpers.dm
@@ -1,4 +1,6 @@
 //Overrides TG's version of the proc - only changes are the examine texts, and the extra DNR check
+//IRIS REMOVAL START
+/*
 /mob/living/carbon/human/generate_death_examine_text()
 	var/mob/dead/observer/ghost = get_ghost(TRUE, TRUE)
 	var/t_He = p_They()
@@ -8,6 +10,8 @@
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; they're still twitching on occasion, perhaps [p_they()] can still be saved..!")
 	else
 		return span_deadsay("[t_He] [t_is] limp and unresponsive; there are no signs of life and they've degraded beyond revival...")
+*/
+//IRIS REMOVAL END
 
 ///copies over clothing preferences like underwear to another human
 /mob/living/carbon/human/copy_clothing_prefs(mob/living/carbon/human/destination)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces nova revival text with tg one along with a check for dnr quirk
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
I'm doing it because people keep shoving afk people into the morgue, less admin work, nova version is inferior since it lacks a check to see if person is disconnected
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
i forgot to take screenshots but it looked fine on my end while using dnr quirk
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: afk dead people should be easier to see if the are revivable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
