### PR TITLE
Adds some embershrooms to the icewalker camp

### DIFF
--- a/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
+++ b/_maps/RandomRuins/IceRuins/nova/icemoon_underground_icewalker_lower.dmm
@@ -189,6 +189,10 @@
 /obj/structure/mineral_door/wood/large_gate,
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"eg" = (
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "ej" = (
 /obj/structure/wall_torch/spawns_lit/directional/north,
 /turf/open/floor/stone/icemoon,
@@ -632,6 +636,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
 /turf/open/floor/stone/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
+"oe" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "of" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2079,6 +2091,13 @@
 /obj/item/forging/hammer/primitive,
 /turf/open/floor/stone/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
+"Uu" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/misc/dirt/icemoon,
+/area/ruin/unpowered/primitive_catgirl_den)
 "UL" = (
 /obj/structure/table/wood,
 /turf/open/floor/stone/icemoon,
@@ -2623,7 +2642,7 @@ Nt
 bH
 gU
 wF
-Yk
+oe
 wF
 aK
 wF
@@ -3628,7 +3647,7 @@ wF
 wF
 Yk
 ut
-Uk
+Uu
 oK
 eS
 JQ
@@ -3732,7 +3751,7 @@ tI
 bX
 RW
 JQ
-tI
+eg
 oK
 oK
 GU


### PR DESCRIPTION
## About The Pull Request

It adds them. 3 on the lower level, where the rest of the mushrooms are.

## Why it's Good for the Game

Every other lavaland mushroom type is in that area, but there being no guaranteed source of embershrooms or fireblossoms means there is no easy access to Tinea Luxor, an ingredient in transmutation fluid

## Proof of Testing

they're there
<img width="212" height="221" alt="dreamseeker_hHYLwIBoac" src="https://github.com/user-attachments/assets/33f10f04-a9de-491f-9d89-562dda3df02c" />
<img width="438" height="434" alt="dreamseeker_a004wROVxo" src="https://github.com/user-attachments/assets/f5785c8f-d9a9-452f-afd7-1021d54a37ac" />
<img width="406" height="281" alt="dreamseeker_061SABWZlD" src="https://github.com/user-attachments/assets/ecda8089-6227-488b-b241-3cb23952f853" />

## Changelog

:cl:
add: Some embershrooms have been added to the icewalker camp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
