### PR TITLE
Radioactive nebula is now actually radioactive

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -497,11 +497,6 @@
 	var/list/shielding = list()
 
 /datum/station_trait/nebula/hostile/process(seconds_per_tick)
-	// NOVA EDIT ADDITION START
-	if(!storms_enabled)
-		get_shielding_level() // So shields still produce tritium
-		return
-	// NOVA EDIT ADDITION END
 	calculate_nebula_strength()
 
 	apply_nebula_effect(nebula_intensity - get_shielding_level())
@@ -566,7 +561,7 @@
 	blacklist = list(/datum/station_trait/random_event_weight_modifier/rad_storms)
 	dynamic_threat_id = "Radioactive Nebula"
 
-	intensity_increment_time = 10 MINUTES // NOVA EDIT longer shield duration - ORIGINAL: intensity_increment_time = 5 MINUTES /
+	intensity_increment_time = 10 MINUTES //IRIS EDIT - OG: 5 MINUTES
 	maximum_nebula_intensity = 1 HOURS + 40 MINUTES
 
 	nebula_layer = /atom/movable/screen/parallax_layer/random/space_gas/radioactive
@@ -688,7 +683,6 @@
 	new /obj/effect/pod_landingzone (get_safe_random_station_turf_equal_weight(), new /obj/structure/closet/supplypod/centcompod (), new /obj/machinery/nebula_shielding/emergency/radiation ())
 
 /datum/station_trait/nebula/hostile/radiation/send_instructions()
-	/* NOVA EDIT REMOVAL START - No more radiation storms on station
 	var/obj/machinery/nebula_shielding/shielder = /obj/machinery/nebula_shielding/radiation
 	var/obj/machinery/gravity_generator/main/innate_shielding = /obj/machinery/gravity_generator/main
 	//How long do we have until the first shielding unit needs to be up?
@@ -707,12 +701,6 @@
 		You have [deadline] before the nebula enters the station. \
 		Every shielding unit will provide an additional [shielder_time] of protection, fully protecting the station with [max_shielders] shielding units.
 	"}
-	NOVA EDIT REMOVAL END */
-	// NOVA EDIT CHANGE START - ORIGINAL: See above
-	var/announcement = {"Your station has been constructed inside a radioactive nebula. \
-		Standard spacesuits will not protect against the nebula and using them is strongly discouraged.
-	"}
-	// NOVA EDIT CHANGE END
 
 	priority_announce(announcement, sound = 'sound/announcer/notice/notice1.ogg')
 

--- a/modular_nova/master_files/code/datums/station_traits/negative_traits.dm
+++ b/modular_nova/master_files/code/datums/station_traits/negative_traits.dm
@@ -1,8 +1,0 @@
-/datum/station_trait/nebula/hostile/
-	/// Radiation storms are disabled by default
-	var/storms_enabled
-
-/// Allows an admin to turn on/off the radiation storms.
-/datum/station_trait/nebula/hostile/proc/toggle_storms()
-	storms_enabled = !storms_enabled
-	message_admins("Radiation storms have been [storms_enabled ? "enabled" : "disabled"]!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7149,7 +7149,6 @@
 #include "modular_nova\master_files\code\datums\quirks\positive_quirks\venomous\venomous_bite_quirk.dm"
 #include "modular_nova\master_files\code\datums\records\manifest.dm"
 #include "modular_nova\master_files\code\datums\records\record.dm"
-#include "modular_nova\master_files\code\datums\station_traits\negative_traits.dm"
 #include "modular_nova\master_files\code\datums\storage\storage.dm"
 #include "modular_nova\master_files\code\datums\storage\subtypes\pockets.dm"
 #include "modular_nova\master_files\code\datums\traits\good.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed some ancient skyrat edits that apparently broke the event
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Our station traits should be fully functional, someone on skyrat wanted to remove it as well but got tired of nobody maintaining it lol
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
<img width="505" height="280" alt="neboola" src="https://github.com/user-attachments/assets/4c9ae4f8-4cb7-4625-bc30-e5ce607a43a5" />

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Restored radioactive nebula storms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
