### PR TITLE
Re-enables sensitive hearing quirk

### DIFF
--- a/modular_nova/master_files/code/datums/traits/good.dm
+++ b/modular_nova/master_files/code/datums/traits/good.dm
@@ -162,8 +162,8 @@
 	name = "Sensitive Hearing"
 	desc = "You can hear even the quietest of sounds, but you're more vulnerable to hearing damage as a result. NOTE: This is a direct downgrade for Teshari!"
 	icon = FA_ICON_HEADPHONES_SIMPLE
-	value = 6
-	hidden_quirk = TRUE // disabled until reworked.
+	value = 10 // IRIS EDIT - 6->10
+	hidden_quirk = FALSE // disabled until reworked. // IRIS EDIT - un-disabled
 	mob_trait = TRAIT_SENSITIVE_HEARING
 	gain_text = span_notice("You could hear a pin drop from 10 feet away.")
 	lose_text = span_danger("Your hearing feels less sensitive.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts https://github.com/NovaSector/NovaSector/pull/6074
Increased price to 10 cuz
<img width="231" height="55" alt="obraz" src="https://github.com/user-attachments/assets/2b31e786-c8bb-405c-9f79-422b86ca7ccd" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
People like it, so it's going back in.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
tmrw

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Re-enabled Sensitive Hearing quirk
balance: Changed Sensitive Hearing price to 10 points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
