### PR TITLE
Makes it so gibbed carbons now spill their blood and reagents onto the floor below them

### DIFF
--- a/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
+++ b/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
@@ -1,0 +1,13 @@
+/mob/living/carbon/gib(drop_bitflags = NONE) // Makes it so gibbing causes all the mobs blood/reagents to spill on the floor
+	var/datum/blood_type/blood_type = get_bloodtype()
+	if(isnull(blood_type))
+		return ..()
+
+	var/turf/pool_location = get_turf(src)
+	var/list/reagents_to_splash = list()
+	reagents_to_splash[blood_type.reagent_type] = blood_volume
+	for(var/datum/reagent/reagent as anything in reagents.reagent_list)
+		reagents_to_splash[reagent.type] = reagent.volume
+
+	pool_location.add_liquid_list(reagents_to_splash, chem_temp = bodytemperature)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6887,6 +6887,7 @@
 #include "modular_iris\master_files\code\modules\clothing\suits\special.dm"
 #include "modular_iris\master_files\code\modules\job\job_types\_job.dm"
 #include "modular_iris\master_files\code\modules\mob\living\blood_types.dm"
+#include "modular_iris\master_files\code\modules\mob\living\carbon\death.dm"
 #include "modular_iris\master_files\code\modules\mob\living\carbon\human\butts.dm"
 #include "modular_iris\master_files\code\modules\mob\living\carbon\human\human.dm"
 #include "modular_iris\master_files\code\modules\reagents\withdrawal\generic_addictions.dm"


### PR DESCRIPTION

## About The Pull Request

- Makes carbons spill all their blood and chemicals on the floor when they are gibbed, this includes xenomorphs and monkeys.

## Why it's Good for the Game

- It makes any scene that has gibbed carbons more dramatic, as gibbing should be
- Additionally it makes more sense for all the blood that carbons have inside of them to be spilled around them when they are deleted from existance (except for literally being deleted from existance)
- Also this allows for more roleplay. When someone gets gibbed by a shuttle all their guts will be inside and you will be able to scoop it up and check if they had alcohol in their blood when dying. 

## Proof of Testing

https://github.com/user-attachments/assets/738dc804-55e0-4e9b-b613-63a3062c2aa3

## Changelog

:cl:
add: Humans, Xenomorphs and monkeys now spill their blood and chemicals in the blood onto the floor when being gibbed
/:cl:
