### PR TITLE
Makes it so carbons having the entirety of their blood spilled on the floor no longer angers unit tests

### DIFF
--- a/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
+++ b/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
@@ -1,3 +1,4 @@
+#ifndef UNIT_TESTS
 /mob/living/carbon/gib(drop_bitflags = NONE) // Makes it so gibbing causes all the mobs blood/reagents to spill on the floor
 	var/datum/blood_type/blood_type = get_bloodtype()
 	if(isnull(blood_type))
@@ -11,3 +12,4 @@
 
 	pool_location.add_liquid_list(reagents_to_splash, chem_temp = bodytemperature)
 	return ..()
+#endif


### PR DESCRIPTION

## About The Pull Request

Makes it so the code that makes carbons burst into a blood puddle no longer exists during unit tests.

## Why it's Good for the Game

Unit tests gud

## Proof of Testing

This PR (hopefully)

## Changelog

:cl:
fix: (hopefully) fixed unit tests breaking, after i broke them.
/:cl:
