### PR TITLE
Fixes holodeck monkeys bursting with blood

### DIFF
--- a/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
+++ b/modular_iris/master_files/code/modules/mob/living/carbon/death.dm
@@ -1,7 +1,7 @@
 #ifndef UNIT_TESTS
 /mob/living/carbon/gib(drop_bitflags = NONE) // Makes it so gibbing causes all the mobs blood/reagents to spill on the floor
 	var/datum/blood_type/blood_type = get_bloodtype()
-	if(isnull(blood_type))
+	if(HAS_TRAIT(src, TRAIT_NOBLOOD) || isnull(blood_type))
 		return ..()
 
 	var/turf/pool_location = get_turf(src)


### PR DESCRIPTION

## About The Pull Request

Title, turns out `get_bloodtype()` will happily give you a blood type even if you don't have blood anymore.

## Why it's Good for the Game

Bug bad

## Changelog

:cl:
fix: holodeck monkeys no longer burst with blood upon being gibbed
/:cl:
