### PR TITLE
Removes voidraptors kitchen tiles with invalid directions

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -400,9 +400,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/structure/bedsheetbin,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "agi" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12231,9 +12229,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "dFh" = (
 /obj/structure/disposalpipe/segment,
@@ -14311,9 +14307,7 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "efP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -17815,9 +17809,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "fgv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -19708,9 +19700,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "fLp" = (
 /turf/closed/wall,
@@ -29253,9 +29243,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "isy" = (
 /obj/effect/decal/remains/human,
@@ -30547,9 +30535,7 @@
 	},
 /obj/structure/towel_bin,
 /obj/structure/table,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "iMf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -33419,9 +33405,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "jzQ" = (
 /obj/structure/table/glass,
@@ -47324,9 +47308,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "noH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58923,9 +58905,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "qsN" = (
 /obj/structure/cable,
@@ -64139,9 +64119,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "rQO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -65621,9 +65599,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "snJ" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -68446,9 +68422,7 @@
 /obj/structure/mop_bucket/janitorialcart{
 	dir = 4
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "sXP" = (
 /obj/structure/cable,
@@ -74951,9 +74925,7 @@
 	pixel_y = 11
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "uJp" = (
 /obj/effect/turf_decal/bot,
@@ -76573,9 +76545,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "vjt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -82856,9 +82826,7 @@
 	},
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/security/prison/work)
 "wUe" = (
 /obj/effect/turf_decal/siding/wood{
@@ -83824,9 +83792,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
+/turf/open/floor/iron/kitchen,
 /area/station/commons/dorms/laundry)
 "xmF" = (
 /obj/structure/cable,


### PR DESCRIPTION

## About The Pull Request

Yeah those exist, and they bug me. I hate them, kitchen tiles don't have directionals.
Dont assign directionals to them, why do they have directionals assigned to them.

## Why it's Good for the Game

Less storage used for variables that don't do anything.

## Changelog

:cl:
map: removed some invalid kitchen tiles on void raptor
/:cl:
