### PR TITLE
Makes voidraptor comfy chairs sane

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -4561,8 +4561,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/primary/aft)
 "bpy" = (
-/obj/structure/chair/comfy{
-	color = "#596479";
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
@@ -5380,9 +5379,7 @@
 "bBU" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch/directional/north,
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#4169e1";
+/obj/structure/chair/comfy/teal{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
@@ -6385,7 +6382,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/comfy/brown{
-	color = "#A46106";
 	dir = 1
 	},
 /obj/effect/landmark/start/quartermaster,
@@ -7661,7 +7657,6 @@
 /area/station/cargo/drone_bay)
 "coO" = (
 /obj/structure/chair/comfy/brown{
-	color = "#A46106";
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
@@ -10548,8 +10543,7 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "dgk" = (
 /obj/machinery/status_display/evac/directional/east,
-/obj/structure/chair/comfy/brown{
-	color = "#EFB341";
+/obj/structure/chair/comfy/yellow{
 	dir = 1
 	},
 /turf/open/floor/carpet/orange,
@@ -12685,9 +12679,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#4169e1";
+/obj/structure/chair/comfy/teal{
 	dir = 8
 	},
 /turf/open/floor/wood/large,
@@ -15452,8 +15444,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/lobby)
 "exx" = (
-/obj/structure/chair/comfy{
-	color = "#596479";
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/dark/opposingcorners{
@@ -25981,8 +25972,7 @@
 /turf/open/floor/iron/smooth_edge,
 /area/station/hallway/primary/aft)
 "hyt" = (
-/obj/structure/chair/comfy/brown{
-	color = "#EFB341";
+/obj/structure/chair/comfy/yellow{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
@@ -27368,10 +27358,7 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
 "hSA" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#4169e1"
-	},
+/obj/structure/chair/comfy/teal,
 /turf/open/floor/carpet/blue,
 /area/station/command/bridge)
 "hSD" = (
@@ -30616,9 +30603,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/power_room)
 "iNL" = (
-/obj/structure/chair/comfy{
-	color = "#596479"
-	},
+/obj/structure/chair/comfy/black,
 /obj/machinery/camera/directional/north{
 	c_tag = "Prison - Library";
 	network = list("ss13","prison")
@@ -31075,9 +31060,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/atmos)
 "iUM" = (
-/obj/structure/chair/comfy/brown{
-	color = "#A46106"
-	},
+/obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/computer/security/telescreen/vault/directional/north,
 /turf/open/floor/carpet/black,
@@ -31447,7 +31430,6 @@
 /area/station/hallway/secondary/service)
 "iYV" = (
 /obj/structure/chair/comfy/brown{
-	color = "#D381C9";
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
@@ -31924,8 +31906,7 @@
 /turf/closed/wall,
 /area/station/security/medical)
 "jfU" = (
-/obj/structure/chair/comfy/brown{
-	color = "#52B4E9";
+/obj/structure/chair/comfy/teal{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
@@ -35116,9 +35097,7 @@
 /obj/machinery/light_switch/directional/west{
 	pixel_x = -23
 	},
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#DE3A3A";
+/obj/structure/chair/comfy/red{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
@@ -39825,10 +39804,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/atmos)
 "lmy" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#DE3A3A"
-	},
+/obj/structure/chair/comfy/red,
 /obj/structure/cable,
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet/royalblack,
@@ -40089,8 +40065,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/ordnance_maint)
 "lpZ" = (
-/obj/structure/chair/comfy/brown{
-	color = "#52B4E9";
+/obj/structure/chair/comfy/teal{
 	dir = 4
 	},
 /obj/effect/landmark/start/chief_medical_officer,
@@ -45495,8 +45470,7 @@
 /area/station/service/kitchen)
 "mPl" = (
 /obj/item/radio/intercom/directional/south,
-/obj/structure/chair/comfy/brown{
-	color = "#9FED58";
+/obj/structure/chair/comfy/lime{
 	dir = 8
 	},
 /obj/effect/landmark/start/head_of_personnel,
@@ -47562,8 +47536,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/aft/lesser)
 "ntp" = (
-/obj/structure/chair/comfy/brown{
-	color = "#9FED58";
+/obj/structure/chair/comfy/lime{
 	dir = 8
 	},
 /obj/machinery/camera/directional/east{
@@ -53041,9 +53014,7 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/engineering/transit_tube)
 "oTf" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#B11111";
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
@@ -57369,8 +57340,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/chair/comfy{
-	color = "#596479";
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark/opposingcorners{
@@ -61107,7 +61077,6 @@
 /area/station/service/chapel)
 "qXY" = (
 /obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
 	dir = 1
 	},
 /obj/machinery/button/door/directional/west{
@@ -70759,8 +70728,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "tCJ" = (
-/obj/structure/chair/comfy/brown{
-	color = "#9FED58";
+/obj/structure/chair/comfy/lime{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
@@ -75556,8 +75524,7 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "uTz" = (
-/obj/structure/chair/comfy/brown{
-	color = "#439C1E";
+/obj/structure/chair/comfy/green{
 	dir = 1
 	},
 /obj/effect/landmark/start/nanotrasen_consultant,
@@ -77276,8 +77243,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "vvf" = (
-/obj/structure/chair/comfy/brown{
-	color = "#439C1E";
+/obj/structure/chair/comfy/green{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
@@ -77629,8 +77595,7 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "vzN" = (
-/obj/structure/chair/comfy{
-	color = "#596479";
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
@@ -78025,8 +77990,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "vGj" = (
-/obj/structure/chair/comfy/brown{
-	color = "#439C1E";
+/obj/structure/chair/comfy/green{
 	dir = 8
 	},
 /obj/effect/landmark/start/nanotrasen_consultant,
@@ -80235,8 +80199,7 @@
 /area/station/maintenance/department/engine/atmos/lesser)
 "wmj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/comfy/brown{
-	color = "#439C1E";
+/obj/structure/chair/comfy/green{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,


### PR DESCRIPTION

## About The Pull Request

Removes color/stackamount vars from comfy chairs, they aren't meant to be touched.

## Why it's Good for the Game

Changing greyscale from grey to brown to blue is dumb and just makes the map larger on DMM scale without providing any value (also you know, you should get iron from destroying chairs)

## Changelog

:cl:
map: removed non-standard comfy chairs from VoidRaptor
/:cl:
