### PR TITLE
Platings get added to loadout

### DIFF
--- a/modular_iris/modules/loadouts/loadout_items/iris_loadout_datum_pocket.dm
+++ b/modular_iris/modules/loadouts/loadout_items/iris_loadout_datum_pocket.dm
@@ -10,7 +10,7 @@
 /datum/loadout_item/pocket_items/plating
 	name = "Standard Plating"
 	item_path = /obj/item/mod/construction/plating
-	restricted_species = list(SPECIES_PROTEAN) // Might have to remove this
+	// restricted_species = list(SPECIES_PROTEAN) // Might have to remove this
 	group = "Species-Unique"
 
 /datum/loadout_item/pocket_items/plating/engineering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, adds platings to the loadout under other, restricted to proteans.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

was requested

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

can't test since proteans aren't merged, might have to just remove the species restriction until that happens

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: ModSuit platings can now be found in the loadout, under Other. Restricted to Proteans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
