### PR TITLE
Ports "Allows admins to recall the end of shift shuttle" from Doppler Shift

### DIFF
--- a/code/modules/admin/verbs/adminshuttle.dm
+++ b/code/modules/admin/verbs/adminshuttle.dm
@@ -53,6 +53,10 @@ ADMIN_VERB(cancel_shuttle, R_ADMIN, "Cancel Shuttle", "Recall the shuttle, regar
 
 	if(tgui_alert(user, "You sure?", "Confirm", list("Yes", "No")) != "Yes")
 		return
+	// IRIS EDIT START - Port  "Revert auto-transfer shuttle" Frop Doppler Shift
+	if(SSshuttle.endvote_passed)
+		SSshuttle.revert_autoEnd()
+	// IRIS  EDIT END
 	SSshuttle.admin_emergency_no_recall = FALSE
 	SSshuttle.emergency.cancel()
 	BLACKBOX_LOG_ADMIN_VERB("Cancel Shuttle")

--- a/modular_iris/doppler_ports/autotransfer/shuttle.dm
+++ b/modular_iris/doppler_ports/autotransfer/shuttle.dm
@@ -1,0 +1,5 @@
+//Ports of https://github.com/DopplerShift13/DopplerShift/pull/622
+/datum/controller/subsystem/shuttle/proc/revert_autoEnd()
+	emergency_no_recall = FALSE
+	endvote_passed = FALSE
+	SSevents.can_fire = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6902,6 +6902,7 @@
 #include "modular_iris\code\game\objects\items\devices\radio.dm"
 #include "modular_iris\code\game\objects\items\food\spaghetti.dm"
 #include "modular_iris\code\game\objects\items\storage\boxes.dm"
+#include "modular_iris\doppler_ports\autotransfer\shuttle.dm"
 #include "modular_iris\eris_ports\aesthetics\code\mob\living\basic\slime\slime.dm"
 #include "modular_iris\eris_ports\aesthetics\code\mob_spawn\corpses\nonhuman_corpses.dm"
 #include "modular_iris\eris_ports\aesthetics\code\research\xenobiology\xenobiology.dm"


### PR DESCRIPTION

## About The Pull Request
https://github.com/DopplerShift13/DopplerShift/pull/622
See Title/PR above: Only thing I didn't port was the renaming of `autoEnd`

## Why it's Good for the Game

Allows admins to cancel the transfer shuttle, in case of a revote and such!

## Proof of Testing

<img width="323" height="501" alt="dreamseeker_CcgP3RSRGr" src="https://github.com/user-attachments/assets/ea11130a-c285-4709-bb16-3fc802407efe" />


## Changelog


:cl:
admin: Admins can finally cancel the transfer shuttle
/:cl:

