### PR TITLE
Plant DNA manipulator machines can now edit Core Genes (stats)

### DIFF
--- a/modular_iris/modules/hydroponics/gene_modder.dm
+++ b/modular_iris/modules/hydroponics/gene_modder.dm
@@ -173,19 +173,19 @@
 				dat += "<span class='highlight'>[target.get_name()]</span> gene with <span class='highlight'>[disk.gene.get_name()]</span>?<br>"
 			if("insert")
 				dat += "<span class='highlight'>[disk.gene.get_name()]</span> gene into \the <span class='highlight'>[seed]</span>?<br>"
-		dat += "</div><div class='line'><a href='?src=[REF(src)];gene=[REF(target)];op=[operation]'>Confirm</a> "
-		dat += "<a href='?src=[REF(src)];abort=1'>Abort</a></div>"
+		dat += "</div><div class='line'><a href='byond://?src=[REF(src)];gene=[REF(target)];op=[operation]'>Confirm</a> "
+		dat += "<a href='byond://?src=[REF(src)];abort=1'>Abort</a></div>"
 		popup.set_content(dat)
 		popup.open()
 		return
 
 	dat+= "<div class='statusDisplay'>"
 
-	dat += "<div class='line'><div class='statusLabel'>Plant Sample:</div><div class='statusValue'><a href='?src=[REF(src)];eject_seed=1'>"
+	dat += "<div class='line'><div class='statusLabel'>Plant Sample:</div><div class='statusValue'><a href='byond://?src=[REF(src)];eject_seed=1'>"
 	dat += seed ? seed.name : "None"
 	dat += "</a></div></div>"
 
-	dat += "<div class='line'><div class='statusLabel'>Data Disk:</div><div class='statusValue'><a href='?src=[REF(src)];eject_disk=1'>"
+	dat += "<div class='line'><div class='statusLabel'>Data Disk:</div><div class='statusValue'><a href='byond://?src=[REF(src)];eject_disk=1'>"
 	if(!disk)
 		dat += "None"
 	else if(!disk.gene)
@@ -208,10 +208,10 @@
 			if(!G)
 				continue
 			dat += "<tr><td width='260px'>[G.get_name()]</td><td>"
-			if(can_extract && G.mutability_flags & PLANT_GENE_GRAFTABLE)
-				dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
-			if(can_insert && istype(disk.gene, G.type) && G.mutability_flags & PLANT_GENE_REMOVABLE)
-				dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=replace'>Replace</a>"
+			if(can_extract)
+				dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
+			if(can_insert && istype(disk.gene, G.type))
+				dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=replace'>Replace</a>"
 			dat += "</td></tr>"
 		dat += "</table></div>"
 
@@ -223,16 +223,16 @@
 					var/datum/plant_gene/G = a
 					dat += "<tr><td width='260px'>[G.get_name()]</td><td>"
 					if(can_extract && G.mutability_flags & PLANT_GENE_GRAFTABLE)
-						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
+						dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
 					if(G.mutability_flags & PLANT_GENE_REMOVABLE)
-						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
+						dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
 					dat += "</td></tr>"
 				dat += "</table>"
 			else
 				dat += "No content-related genes detected in sample.<br>"
 			dat += "</div>"
 			if(can_insert && istype(disk.gene, /datum/plant_gene/reagent))
-				dat += "<a href='?src=[REF(src)];op=insert'>Insert: [disk.gene.get_name()]</a>"
+				dat += "<a href='byond://?src=[REF(src)];op=insert'>Insert: [disk.gene.get_name()]</a>"
 
 			dat += "<div class='line'><h3>Trait Genes</h3></div><div class='statusDisplay'>"
 			if(trait_genes.len)
@@ -241,15 +241,15 @@
 					var/datum/plant_gene/G = a
 					dat += "<tr><td width='260px'>[G.get_name()]</td><td>"
 					if(can_extract && G.mutability_flags & PLANT_GENE_GRAFTABLE)
-						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
+						dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
 					if(G.mutability_flags & PLANT_GENE_REMOVABLE)
-						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
+						dat += "<a href='byond://?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
 					dat += "</td></tr>"
 				dat += "</table>"
 			else
 				dat += "No trait-related genes detected in sample.<br>"
 			if(can_insert && istype(disk.gene, /datum/plant_gene/trait))
-				dat += "<a href='?src=[REF(src)];op=insert'>Insert: [disk.gene.get_name()]</a>"
+				dat += "<a href='byond://?src=[REF(src)];op=insert'>Insert: [disk.gene.get_name()]</a>"
 			dat += "</div>"
 	else
 		dat += "<br>No sample found.<br><span class='highlight'>Please, insert a plant sample to use this device.</span>"
@@ -315,6 +315,7 @@
 					repaint_seed()
 				if("extract")
 					if(disk && !disk.read_only)
+						disk.gene = G
 						seed.genes -= G
 						var/datum/plant_gene/core/gene = G
 						if(istype(G, /datum/plant_gene/core))
@@ -342,6 +343,8 @@
 					if(disk && disk.gene && istype(disk.gene, G.type) && istype(G, /datum/plant_gene/core))
 						seed.genes -= G
 						var/datum/plant_gene/core/C = disk.gene.Copy()
+						var/datum/plant_gene/core/disk_core = disk.gene
+						C.value = disk_core.value
 						seed.genes += C
 						C.apply_stat(seed)
 						repaint_seed()

--- a/modular_iris/modules/research/code/designs/machine_board_designs.dm
+++ b/modular_iris/modules/research/code/designs/machine_board_designs.dm
@@ -1,9 +1,9 @@
 /datum/design/board/plantgenes
-	name = "Plant Gene Editor Board"
+	name = "Plant DNA Manipulator Board"
 	desc = "The circuit board for a plant gene editing machine."
 	id = "plantgene"
 	build_path = /obj/item/circuitboard/machine/plantgenes
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_SERVICE
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_BOTANY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE


### PR DESCRIPTION
## About The Pull Request
So since I ported the Plant Gene editor from Bubber, it turns out that a change they did to the machine was causing it so you could extract stats, but not inject them into new seeds. This fixes that AND keeps the balance they implemented!
Also adjust the name in research and location in service's tech fab
## Why it's Good for the Game

Lotta code going to waste before, now it can be used!

## Proof of Testing

<img width="450" height="600" alt="nkDpOyVNty" src="https://github.com/user-attachments/assets/199cb140-4dc2-4cb7-8645-53007b5c3193" />


## Changelog


:cl:
fix: Plant Gene editors can now replace Core Genes (stats)
/:cl:

