### PR TITLE
Fixes yellow crystalline pylons not updating a cell's icon on recharging it

### DIFF
--- a/modular_iris/modules/research/code/xenobiology/crossbreeding/crystalized.dm
+++ b/modular_iris/modules/research/code/xenobiology/crossbreeding/crystalized.dm
@@ -260,7 +260,7 @@
 	if(!istype(cell))
 		return ..()
 	if(cell.charge == cell.maxcharge) //Punishment for greed
-		to_chat(span_danger(" You try to charge the cell, but it is already fully energized. You are not sure if this was a good idea..."))
+		to_chat(user, span_danger(" You try to charge the cell, but it is already fully energized. You are not sure if this was a good idea..."))
 		cell.explode()
 		return
 	to_chat(user, span_notice("You charged the [cell.name] on [name]!"))


### PR DESCRIPTION
## About The Pull Request

What it says on da tin (also btw whilst there i cleaned the proc up a tiny bit by adding an early return, this is just adding `update_appearance()` after `give()`
Fixes:
- #484

## Why it's Good for the Game

Bug bad, someone could think the battery is still not recharged and explode it.

## Proof of Testing

Tested locally before and after, trust me bro it works. This does not have any negative consequences.

## Changelog

:cl:
fix: fixed yellow crystalline pylons not properly updating a cell's icon
/:cl:
