### PR TITLE
disables the worst offenders of the condos 

### DIFF
--- a/modular_nova/modules/condos/condo_templates.dm
+++ b/modular_nova/modules/condos/condo_templates.dm
@@ -140,11 +140,11 @@ Due to some fuckery with how these templates work; the bottom left turf of your 
 	landing_zone_x_offset = 7
 	landing_zone_y_offset = 1
 
-/datum/map_template/condo/mountainside_apartment
-	name = "Condo - Mountainside Apartment"
-	mappath = "modular_nova/modules/condos/_maps/apartment_mountainside.dmm"
-	landing_zone_x_offset = 14
-	landing_zone_y_offset = 4
+// /datum/map_template/condo/mountainside_apartment //IRIS EDIT: doesnt seem too bad so can probably be salvaged, but definitely needs a lot of a rework to fit iris
+//	name = "Condo - Mountainside Apartment"
+//	mappath = "modular_nova/modules/condos/_maps/apartment_mountainside.dmm"
+//	landing_zone_x_offset = 14
+//	landing_zone_y_offset = 4
 
 /datum/map_template/condo/mountainside_fortuneteller
 	name = "Condo - Fortune Teller Apartment"
@@ -158,11 +158,11 @@ Due to some fuckery with how these templates work; the bottom left turf of your 
 	landing_zone_x_offset = 17
 	landing_zone_y_offset = 3
 
-/datum/map_template/condo/mountainside_dragonlair
-	name = "Condo - Dragon's Lair"
-	mappath = "modular_nova/modules/condos/_maps/apartment_dragonslair.dmm"
-	landing_zone_x_offset = 5
-	landing_zone_y_offset = 11
+// /datum/map_template/condo/mountainside_dragonlair //IRIS EDIT: absolutely not
+// 	name = "Condo - Dragon's Lair"
+// 	mappath = "modular_nova/modules/condos/_maps/apartment_dragonslair.dmm"
+// 	landing_zone_x_offset = 5
+// 	landing_zone_y_offset = 11
 
 /datum/map_template/condo/deepspace_ship
 	name = "Condo - Deepspace Ship"


### PR DESCRIPTION
the next time copilot suggests a description to me im going to fucking kill someone

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ill review more of them later but for now:

- disables dragons lair pending complete removal (do i need to say what the problem with that one is)
- also disables mountainside apartment until i can be bothered to make it look Less Weird and remove the broken sprites

other than that doesnt touch the other condos, map files are untouched this just webedit disables them temporarily
## Why it's Good for the Game

bleh

## Proof of Testing

# No
(im commenting out datums this is the sort of shit that physically cannot break)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Johnson & Company's research department happens to have lost a large amount of pipe bombs they were storing inside the mountainside apartment condo and the dragon's lair one. They have been obliterated as a result.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
