### PR TITLE
Fixes sign language overwriting non-default speech bubbles.

### DIFF
--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -111,7 +111,7 @@
 	carbon_parent.verb_whisper = initial(carbon_parent.verb_whisper)
 	carbon_parent.verb_sing = initial(carbon_parent.verb_sing)
 	carbon_parent.verb_yell = initial(carbon_parent.verb_yell)
-	carbon_parent.bubble_icon = get_parent_bubble_icon(carbon_parent)
+	carbon_parent.bubble_icon = get_parent_bubble_icon(carbon_parent) //IRIS EDIT, originally carbon_parent.bubble_icon = initial(carbon_parent.bubble_icon)
 
 	UnregisterSignal(carbon_parent, list(
 		COMSIG_CARBON_GAIN_ORGAN,
@@ -124,7 +124,7 @@
 	))
 	return TRUE
 
-
+///IRIS EDIT START
 /// Retrieves the highest priority bubble icon for the parent carbon, if any.
 /// Copy of /datum/component/bubble_icon_override/proc/get_bubble_icon(mob/living/target)
 /datum/component/sign_language/proc/get_parent_bubble_icon(mob/living/carbon/carbon_parent)
@@ -132,6 +132,7 @@
 	SEND_SIGNAL(carbon_parent, COMSIG_GET_BUBBLE_ICON, holder)
 	var/bubble_icon = holder[1]
 	return bubble_icon || initial(carbon_parent.bubble_icon)
+///IRIS EDIT END
 
 ///Signal proc for [COMSIG_CARBON_GAIN_ORGAN]
 ///Applies the new say mod to any tongues that have appeared!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if you have the signer quirk, and are a species with a unique typing speech bubble, swapping in and out of sign language permanently replaces the vocal speech bubble with the default human one.

This should allow the bubble to be restored properly after toggling out of sign language.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

Prevents species confusion, helps players maintain their character's identity!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<img width="276" height="296" alt="image" src="https://github.com/user-attachments/assets/d47e67b3-b41b-4d41-b319-e170f10f5eed" />
<img width="287" height="302" alt="image" src="https://github.com/user-attachments/assets/7b9257b4-40ab-438d-9c47-c6e9fa779878" />
<img width="267" height="305" alt="image" src="https://github.com/user-attachments/assets/326a6d02-1179-4d3f-b3ce-4df9f92f208a" />

Please take my word that it's in sequence.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Allows species/tongue specific speech bubbles to be restores after using sign language.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
