### PR TITLE
Gives BO a command intercom mount

### DIFF
--- a/modular_iris/modules/bridge_assistant/command_intercom.dm
+++ b/modular_iris/modules/bridge_assistant/command_intercom.dm
@@ -1,0 +1,16 @@
+/obj/item/radio/intercom/command/unscrewed
+	unscrewed = TRUE
+
+/obj/item/wallframe/intercom/command
+	name = "command intercom frame"
+	result_path = /obj/item/radio/intercom/command/unscrewed
+
+/obj/item/radio/intercom/command/atom_deconstruct(disassembled)
+	new/obj/item/wallframe/intercom/command(get_turf(src))
+
+/obj/structure/closet/secure_closet/bridge_officer/PopulateContents()
+	..()
+	new /obj/item/wallframe/intercom/command(src)
+	new /obj/item/paper/fluff/jobs/engineering/frequencies(src)
+
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7013,6 +7013,7 @@
 #include "modular_iris\modules\blooper\bark_list.dm"
 #include "modular_iris\modules\bodyparts\ethereal_bodyparts.dm"
 #include "modular_iris\modules\bodyparts\code\_mutant_bodyparts.dm"
+#include "modular_iris\modules\bridge_assistant\command_intercom.dm"
 #include "modular_iris\modules\bubber_ports\nekorolls\code\nekorolls.dm"
 #include "modular_iris\modules\cargo\packs\engineering.dm"
 #include "modular_iris\modules\cargo_bounties\code\bounty_cubes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Command intercom is a stationary radio with no limits to frequencies. It's a really fun toy for BO, allowing them (a role that basically lives near all the status consoles) to communicate important information directly to a department. But unfortunately, most maps do not have one. This fixes that by adding a frame (and a paper with frequencies) to BO's locker.

Also, makes it so you can take it off the wall without it defaulting to a basic intercom.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
It's a really fun tool!
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
<img width="292" height="123" alt="obraz" src="https://github.com/user-attachments/assets/cc08eb4d-85cb-4aca-b806-b8199a8ea4f0" />
<img width="443" height="151" alt="obraz" src="https://github.com/user-attachments/assets/3893d9d1-1139-4c33-9059-e3416b0fee4c" />
<img width="454" height="94" alt="obraz" src="https://github.com/user-attachments/assets/5ff16d3d-9cd1-4734-a36d-d98a95590f5b" />

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Bridge Officer's locker now starts with a command intercom mount and a paper with dept frequencies listed.
fix: Command intercom, when dismantled, no longer defaults to a basic intercom frame.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
