### PR TITLE
Holosynths: Keep ID, belt and pockets + Bug Fix

### DIFF
--- a/modular_iris/doppler_ports/species/holosynth/code/holopassthrough.dm
+++ b/modular_iris/doppler_ports/species/holosynth/code/holopassthrough.dm
@@ -19,13 +19,18 @@
 	passwindow_on(owner, type)
 
 	//Need this to happen post timer but pre move. Otherwise touching glass will instantly strip ppl
-	owner.unequip_everything()
+	for(var/obj/item/I in ascarbon.get_equipped_items(TRUE))
+		var/slot = ascarbon.get_slot_by_item(I)
+		// The intent: let's not drop items that are in the belt, id, or pockets, etc.
+		if(slot & (ITEM_SLOT_BELT | ITEM_SLOT_ID | ITEM_SLOT_ICLOTHING | ITEM_SLOT_LPOCKET | ITEM_SLOT_RPOCKET))
+			continue
+		ascarbon.dropItemToGround(I)
 
 	//We need to do this twice if it's a full window bc otherwise they could reach behind them for their items
-	var/dirToMove = get_dir(owner, bumpee)
-	try_move_adjacent(owner, dirToMove)
+	var/dirToMove = get_dir(owner, bumpee) || owner.dir
+	step(owner, dirToMove)
 	if(wumpee.fulltile)
-		try_move_adjacent(owner, dirToMove)
+		step(owner, dirToMove)
 
 	passwindow_off(owner, type)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This updates the holosynth ability to phase through glass. The holosynth will now keep items in their belt, ID and pockets. Everything else will drop before they phase through.

There was also a minor bug where if all items dropped from the holosynth, the next phase abilities they trigger would only launch them south. This is also fixed.


## Why it's Good for the Game

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Implements the holo passthrough ability to the intended vision.

## Proof of Testing


https://github.com/user-attachments/assets/33a61c33-a002-40a8-9299-d386b77ece15



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: holopassthrough ability for holosynths now drops items that are not ID, belt and pocket items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
