### PR TITLE
Emergency Loadout Fix (FUCKING HELL)

### DIFF
--- a/code/modules/loadout/categories/suits.dm
+++ b/code/modules/loadout/categories/suits.dm
@@ -17,9 +17,9 @@
 	list/datum/loadout_item/all_loadout_items,
 )
 	var/list/datum/loadout_item/suit/other_suits = list()
-    for(var/datum/loadout_item/other_suit in all_loadout_items)
-        if(istype(other_suit, /datum/loadout_item/suit) && other_suit.category == src)
-            other_suits += other_suit
+	for(var/datum/loadout_item/other_suit in all_loadout_items)
+		if(istype(other_suit, /datum/loadout_item/suit) && other_suit.category == src)
+			other_suits += other_suit
 
 	if(length(other_suits) >= max_allowed)
 		// We only need to deselect something if we're above the limit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes loadouts work again. Please.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Fuck my stupid baka life 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
NO TIME FOR ALL THAT
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: prodirus
fix: loadout should once again work as intended (yell at CloudyNewt for that blunder)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
